### PR TITLE
Add Makefile with nwg-dock-hyprland symlink alias + install paths (#96)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,24 +161,24 @@ setup-sway:
 upgrade: build-release
 	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) $(LEGACY_BIN_NAME) 2>/dev/null || true)"; \
 	if [ -n "$$RUNNING_PIDS" ]; then \
-		ARGS_FILE="$$(mktemp)"; \
+		ARGS_FILE="$$(mktemp)" || exit 1; \
+		trap 'rm -f "$$ARGS_FILE"' EXIT; \
 		for pid in $$RUNNING_PIDS; do \
-			"$(DESTDIR)$(BINDIR)/$(BIN_NAME)" --dump-args "$$pid" 2>/dev/null >> "$$ARGS_FILE" || true; \
+			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || exit 1; \
 		done; \
 		echo "Stopping running instance(s): $$RUNNING_PIDS"; \
 		kill $$RUNNING_PIDS 2>/dev/null || true; \
 		sleep 1; \
-		$(MAKE) install-bin install-data; \
+		$(MAKE) install-bin install-data || exit 1; \
 		if [ -s "$$ARGS_FILE" ]; then \
 			while IFS= read -r args; do \
 				echo "Restarting with captured args: $$args"; \
 				setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
 			done < "$$ARGS_FILE"; \
 		fi; \
-		rm -f "$$ARGS_FILE"; \
 	else \
 		echo "No running instance — installing without restart"; \
-		$(MAKE) install-bin install-data; \
+		$(MAKE) install-bin install-data || exit 1; \
 	fi
 	@echo "Upgrade complete."
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,211 @@
+# Makefile for nwg-dock — binary-repo subset per epic §3.6.
+#
+# Default install target is /usr/local (LSB convention for locally-built
+# software). Contributors iterating from a clone should use the no-sudo
+# override:
+#   make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+# Go-predecessor parity is an opt-in:
+#   sudo make install PREFIX=/usr
+#
+# The binary renames from nwg-dock-hyprland → nwg-dock (epic §3.1), but
+# DATA + CONFIG paths still reference `nwg-dock-hyprland/` to preserve
+# existing users' `~/.config/nwg-dock-hyprland/style.css` customizations
+# across upgrade. Future release may unify paths with a migration step.
+
+CARGO   ?= cargo
+PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
+DATADIR ?= $(PREFIX)/share
+DESTDIR ?=
+
+# Go-predecessor data-dir name — see header comment.
+DATA_APP_NAME := nwg-dock-hyprland
+# New binary name + legacy symlink target for backwards-compat.
+BIN_NAME        := nwg-dock
+LEGACY_BIN_NAME := nwg-dock-hyprland
+
+SONAR_SCANNER ?= /opt/sonar-scanner/bin/sonar-scanner
+SONAR_HOST_URL ?= https://sonar.aaru.network
+SONAR_TRUSTSTORE ?= /tmp/sonar-truststore.jks
+SONAR_TRUSTSTORE_PASSWORD ?= changeit
+
+.PHONY: all build build-release test test-integration lint check-tools \
+        lint-fmt lint-clippy lint-test lint-deny lint-audit \
+        install install-bin install-data uninstall \
+        setup-hyprland setup-sway upgrade \
+        sonar clean help
+
+all: build
+
+define HELP_TEXT
+Targets:
+  make build           Debug build
+  make build-release   Release build (used by install + upgrade)
+  make test            cargo test + cargo clippy --all-targets
+  make test-integration tests/integration/test_runner.sh (requires sway + foot)
+  make lint            Full local check: fmt + clippy + test + deny + audit
+  make install         Build release + install binary + install data
+  make install-bin     Install binary to $(DESTDIR)$(BINDIR) + nwg-dock-hyprland symlink alias
+  make install-data    Install data assets to $(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/
+  make uninstall       Remove installed binary, symlink, and data
+  make setup-hyprland  Print Hyprland autostart snippet
+  make setup-sway      Print Sway autostart snippet
+  make upgrade         Capture running args, stop, rebuild, install, restart
+  make sonar           Run SonarQube scan (requires sonar-scanner + .env)
+  make clean           cargo clean
+
+Install-path invocations:
+  sudo make install                                              # default /usr/local
+  make install PREFIX=$$HOME/.local BINDIR=$$HOME/.cargo/bin     # no-sudo dev
+  sudo make install PREFIX=/usr                                  # distro-parity
+endef
+export HELP_TEXT
+
+help:
+	@echo "$$HELP_TEXT"
+
+build:
+	$(CARGO) build
+
+build-release:
+	$(CARGO) build --release
+
+test:
+	$(CARGO) test
+	$(CARGO) clippy --all-targets
+
+test-integration: build-release
+	@echo "Running headless Sway integration tests..."
+	@bash tests/integration/test_runner.sh
+
+check-tools:
+	@if ! command -v cargo-deny >/dev/null 2>&1; then \
+		echo "Installing cargo-deny..."; \
+		$(CARGO) install cargo-deny; \
+	fi
+	@if ! command -v cargo-audit >/dev/null 2>&1; then \
+		echo "Installing cargo-audit..."; \
+		$(CARGO) install cargo-audit; \
+	fi
+
+# Individual lint subtargets — each runnable on its own.
+lint-fmt:
+	@echo "── Format ──"
+	$(CARGO) fmt --all --check
+
+lint-clippy:
+	@echo "── Clippy ──"
+	$(CARGO) clippy --all-targets -- -D warnings
+
+# Plain test (no clippy) so `make lint` runs clippy exactly once via lint-clippy.
+lint-test:
+	@echo "── Tests ──"
+	$(CARGO) test
+
+lint-deny:
+	@echo "── Cargo Deny (licenses, advisories, bans, sources) ──"
+	$(CARGO) deny check
+
+lint-audit:
+	@echo "── Cargo Audit (dependency CVEs) ──"
+	$(CARGO) audit
+
+lint: check-tools lint-fmt lint-clippy lint-test lint-deny lint-audit
+	@echo ""
+	@echo "All local checks passed ✓"
+
+# ─────────────────────────────────────────────────────────────────────
+# Install / uninstall
+# ─────────────────────────────────────────────────────────────────────
+
+install: build-release install-bin install-data
+
+install-bin:
+	@echo "Installing binary to $(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+	install -D -m 755 target/release/$(BIN_NAME) "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+	@echo "Creating legacy-name symlink: $(LEGACY_BIN_NAME) → $(BIN_NAME)"
+	ln -sf $(BIN_NAME) "$(DESTDIR)$(BINDIR)/$(LEGACY_BIN_NAME)"
+
+install-data:
+	@echo "Installing data assets to $(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/"
+	install -d "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/images"
+	install -m 644 data/$(DATA_APP_NAME)/style.css "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/"
+	install -m 644 data/$(DATA_APP_NAME)/images/*.svg "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/images/"
+
+uninstall:
+	@echo "Removing binary + symlink + data"
+	rm -f "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+	rm -f "$(DESTDIR)$(BINDIR)/$(LEGACY_BIN_NAME)"
+	rm -rf "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)"
+	@echo "Uninstalled."
+
+# ─────────────────────────────────────────────────────────────────────
+# Compositor setup helpers
+# ─────────────────────────────────────────────────────────────────────
+
+setup-hyprland:
+	@echo "# Add to ~/.config/hypr/autostart.conf:"
+	@echo "exec-once = uwsm-app -- $(BIN_NAME) -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c \"nwg-drawer --pb-auto\""
+
+setup-sway:
+	@echo "# Add to ~/.config/sway/config:"
+	@echo "exec_always $(BIN_NAME) -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c \"nwg-drawer --pb-auto\""
+
+# ─────────────────────────────────────────────────────────────────────
+# Upgrade — capture running args, stop, rebuild+install, restart
+# ─────────────────────────────────────────────────────────────────────
+#
+# `pidof -c` matches against the binary's comm field, which stays the
+# same across the symlink alias — so we pass both names to cover users
+# still running via the `nwg-dock-hyprland` symlink.
+upgrade: build-release
+	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) $(LEGACY_BIN_NAME) 2>/dev/null || true)"; \
+	if [ -n "$$RUNNING_PIDS" ]; then \
+		ARGS_FILE="$$(mktemp)"; \
+		for pid in $$RUNNING_PIDS; do \
+			"$(DESTDIR)$(BINDIR)/$(BIN_NAME)" --dump-args "$$pid" 2>/dev/null >> "$$ARGS_FILE" || true; \
+		done; \
+		echo "Stopping running instance(s): $$RUNNING_PIDS"; \
+		kill $$RUNNING_PIDS 2>/dev/null || true; \
+		sleep 1; \
+		$(MAKE) install-bin install-data; \
+		if [ -s "$$ARGS_FILE" ]; then \
+			while IFS= read -r args; do \
+				echo "Restarting with captured args: $$args"; \
+				setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
+			done < "$$ARGS_FILE"; \
+		fi; \
+		rm -f "$$ARGS_FILE"; \
+	else \
+		echo "No running instance — installing without restart"; \
+		$(MAKE) install-bin install-data; \
+	fi
+	@echo "Upgrade complete."
+
+# ─────────────────────────────────────────────────────────────────────
+# SonarQube scan — .env is PARSED (never sourced) to avoid shell injection.
+# ─────────────────────────────────────────────────────────────────────
+
+sonar:
+	@echo "Running SonarQube scan..."
+	@test -f ./.env || { echo "ERROR: .env not found in repo root"; exit 1; }
+	@command -v "$(SONAR_SCANNER)" >/dev/null 2>&1 || [ -x "$(SONAR_SCANNER)" ] || { \
+		echo "ERROR: sonar-scanner not found (looked at $(SONAR_SCANNER))"; exit 1; \
+	}
+	@test -r "$(SONAR_TRUSTSTORE)" || { \
+		echo "ERROR: truststore not found or not readable at $(SONAR_TRUSTSTORE)"; \
+		echo "  (sonar.aaru.network uses a self-signed cert — regenerate with:"; \
+		echo "     openssl s_client -connect sonar.aaru.network:443 -showcerts </dev/null 2>/dev/null \\\\"; \
+		echo "       | awk '/BEGIN CERT/,/END CERT/' > /tmp/sonar-cert.pem && \\\\"; \
+		echo "     keytool -importcert -alias sonar-aaru -file /tmp/sonar-cert.pem \\\\"; \
+		echo "       -keystore $(SONAR_TRUSTSTORE) -storepass $(SONAR_TRUSTSTORE_PASSWORD) -noprompt)"; \
+		exit 1; \
+	}
+	@TOKEN="$$(awk '/^SONAR_TOKEN=/{sub(/^[^=]*=[ \t]*/, ""); sub(/[ \t]+$$/, ""); print; exit}' ./.env)"; \
+	test -n "$$TOKEN" || { echo "ERROR: SONAR_TOKEN is empty in .env"; exit 1; }; \
+	SONAR_TOKEN="$$TOKEN" \
+	SONAR_SCANNER_OPTS="-Djavax.net.ssl.trustStore=$(SONAR_TRUSTSTORE) -Djavax.net.ssl.trustStorePassword=$(SONAR_TRUSTSTORE_PASSWORD)" \
+	"$(SONAR_SCANNER)" -Dsonar.host.url="$(SONAR_HOST_URL)"
+
+clean:
+	$(CARGO) clean

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo make install
 Writes:
 - `nwg-dock` → `/usr/local/bin/nwg-dock`
 - Legacy symlink → `/usr/local/bin/nwg-dock-hyprland` (so old autostart lines keep working)
-- Data files → `/usr/local/share/nwg-dock/`
+- Data files → `/usr/local/share/nwg-dock-hyprland/` (path kept on the Go-predecessor convention so existing users' `~/.config/nwg-dock-hyprland/style.css` customizations keep resolving — a full-rename migration is planned for a later minor)
 
 **No-sudo, dev workflow (useful when working from a clone):**
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,32 +1,29 @@
 # SonarQube project configuration
-#
-# TEMPLATE — this file is copied into each per-tool repo as part of the
-# Phase 1–4 extractions (#80). Before committing, replace:
-#   nwg-dock    e.g. nwg-common / nwg-dock / nwg-drawer / nwg-notifications
-# The SonarQube project itself must be created server-side first
-# (see CHECKLIST.md in this template dir).
 
 sonar.projectKey=nwg-dock
 sonar.projectName=nwg-dock
 sonar.projectVersion=0.3.0
 
-# Source code location
-sonar.sources=crates
+# Source code location — standalone repo has src/ at root (not crates/*/src/)
+sonar.sources=src
 
 # Test sources must be set BEFORE sonar.test.inclusions — the inclusion
-# pattern filters files within this scope. Leaving it undefined silently
-# produces incomplete test classification.
-sonar.tests=crates
+# pattern filters files within this scope. Listing both `src` and `tests`
+# means the pattern catches inline `#[cfg(test)] mod tests` in sources AND
+# any Cargo integration tests under top-level tests/ (and the headless Sway
+# shell scripts under tests/integration/).
+sonar.tests=src,tests
 
-# Rust source files
+# Rust source files — note: the binary-repo code is Rust only, but
+# tests/integration/*.sh lives here too. The inclusions pattern scopes
+# Rust-level analysis to .rs files; Sonar's shell analyzer can still
+# find the .sh files under tests/.
 sonar.inclusions=**/*.rs
 
 # Exclude non-source files
 sonar.exclusions=**/target/**
 
 # Test file pattern — any file under a tests/ directory at any depth.
-# (Our codebase uses inline `#[cfg(test)] mod tests` at the bottom of
-# each .rs file; separate integration tests live under `crates/*/tests/`.)
 sonar.test.inclusions=**/tests/**
 
 # Encoding


### PR DESCRIPTION
## Summary
Per-repo Makefile per epic §3.6 — gives the dock its per-repo build / install / upgrade surface and lands the `nwg-dock-hyprland` → `nwg-dock` symlink alias that keeps existing autostart lines working.

Sandbox-verified: `DESTDIR=/tmp/nwg-dock-install PREFIX=/opt make install` drops `nwg-dock` + `nwg-dock-hyprland` symlink in `$BINDIR` and `style.css` + images in `$DATADIR/nwg-dock-hyprland/`; `make uninstall` removes them cleanly.

## Install-path invocations (all documented in README.md + `make help`)

| Invocation | BINDIR | DATADIR |
|---|---|---|
| `sudo make install` (default) | `/usr/local/bin` | `/usr/local/share/nwg-dock-hyprland/` |
| `make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin` (no-sudo dev) | `~/.cargo/bin` | `~/.local/share/nwg-dock-hyprland/` |
| `sudo make install PREFIX=/usr` (distro-parity) | `/usr/bin` | `/usr/share/nwg-dock-hyprland/` |

## Design note: data path kept as `nwg-dock-hyprland/`

The binary renamed (`nwg-dock-hyprland` → `nwg-dock`) but the DATA + CONFIG paths stayed on the Go-predecessor convention. Rationale: the dock's Rust code still looks up assets via `paths::find_data_home("nwg-dock-hyprland")` and user CSS under `~/.config/nwg-dock-hyprland/style.css`. Renaming those would break existing users' customizations on upgrade. A full path rename (with a one-time config migration) is planned for a later minor. Documented in the Makefile header comment + README "Installation" section.

## Targets
- `build`, `build-release`, `test`, `test-integration`, `lint` (+ `lint-fmt` / `lint-clippy` / `lint-test` / `lint-deny` / `lint-audit` subtargets)
- `install`, `install-bin` (with symlink creation), `install-data`, `uninstall`
- `setup-hyprland`, `setup-sway` — print autostart snippets using the canonical `nwg-dock` command
- `upgrade` — `pidof -c nwg-dock nwg-dock-hyprland` finds running process under either invocation name, captures args via `--dump-args`, stops, rebuilds + installs, restarts
- `sonar` — hardened per the nwg-common pattern: `.env` parsed via awk (not sourced), truststore preflight with regen recipe, SONAR_SCANNER / SONAR_HOST_URL / SONAR_TRUSTSTORE all `?=` overridable
- `clean`, `help`

## Also touched
- **`sonar-project.properties`** — paths fixed for standalone layout (`sources=src` not `crates`, `tests=src,tests`) matching the nwg-common convention. `make sonar` upload verified green.
- **`README.md`** — `Data files → /usr/local/share/nwg-dock/` corrected to `/usr/local/share/nwg-dock-hyprland/` with a note on the Go-predecessor-name continuity.

## Test plan
- [x] `make help` reads correctly
- [x] `make build` + `make test` + `make lint` green
- [x] Sandbox `DESTDIR=/tmp/… make install` + `make uninstall` cycle clean
- [x] Symlink correctly points `nwg-dock-hyprland` → `nwg-dock`
- [x] `make sonar` uploads analysis (visible at sonar.aaru.network)
- [ ] CI + CodeRabbit review

Closes #96.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation docs updated to use the nwg-dock-hyprland data path so existing customizations remain compatible; notes on planned future rename included.

* **Chores**
  * Added a top-level build/test/lint/install toolchain with targets for build, test, lint, install/uninstall, and upgrade flows; integration test and SonarQube scan workflows included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->