### PR TITLE
Fix dogfood findings: `--version` string + upgrade target hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,19 +157,67 @@ setup-sway:
 #
 # `pidof -c` matches against the binary's comm field, which stays the
 # same across the symlink alias — so we pass both names to cover users
-# still running via the `nwg-dock-hyprland` symlink.
+# still running via the `nwg-dock-hyprland` symlink. The output is
+# pipelined through `sort -u` to dedupe — a process launched via the
+# symlink gets reported under both names, which would otherwise cause
+# --dump-args + kill + restart to run twice on the same pid.
+#
+# Install-target validation (issue #35): before killing anything,
+# resolve /proc/$PID/exe for each running dock and compare against
+# where this upgrade would install ($(BINDIR)/$(BIN_NAME)). If they
+# don't match — usually because the user installed to ~/.cargo/bin
+# but invoked upgrade without re-passing PREFIX/BINDIR, so we'd try
+# to install to /usr/local and fail on permission — we abort with a
+# helpful error BEFORE touching the dock. Previously the recipe
+# killed the dock first and then failed the install, leaving the
+# desktop with no visible dock and no binary update.
+#
+# Symlink handling: /proc/$pid/exe is a kernel-resolved canonical
+# path, not a symlink. `readlink -f` on both sides (running exe +
+# install target) ensures the comparison works even when the user
+# launched via the `nwg-dock-hyprland` alias (the alias resolves to
+# the nwg-dock binary's real path, which is what /proc reports).
+#
+# Atomicity: recipe order is validate → capture args → install →
+# kill → restart. Install happens while the dock is still running
+# (Linux's mmap semantics make this safe — `install` unlinks the
+# destination and writes a new file; the running process's loaded
+# pages survive intact until the process exits). If install fails,
+# the dock is never killed.
 upgrade: build-release
-	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) $(LEGACY_BIN_NAME) 2>/dev/null || true)"; \
+	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) $(LEGACY_BIN_NAME) 2>/dev/null | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $$//' || true)"; \
 	if [ -n "$$RUNNING_PIDS" ]; then \
+		INSTALL_TARGET="$(DESTDIR)$(BINDIR)/$(BIN_NAME)"; \
+		INSTALL_TARGET_REAL="$$(readlink -f "$$INSTALL_TARGET" 2>/dev/null || echo "$$INSTALL_TARGET")"; \
+		for pid in $$RUNNING_PIDS; do \
+			RUNNING_EXE="$$(readlink -f "/proc/$$pid/exe" 2>/dev/null)"; \
+			test -n "$$RUNNING_EXE" || continue; \
+			if [ "$$RUNNING_EXE" != "$$INSTALL_TARGET_REAL" ]; then \
+				RUNNING_BINDIR="$$(dirname "$$RUNNING_EXE")"; \
+				RUNNING_PREFIX="$$(dirname "$$RUNNING_BINDIR")"; \
+				echo "ERROR: running dock (pid $$pid) is installed at"; \
+				echo "         $$RUNNING_EXE"; \
+				echo "       but 'make upgrade' would install to"; \
+				echo "         $$INSTALL_TARGET"; \
+				echo ""; \
+				echo "       Dock NOT killed — a prefix-mismatched upgrade would leave"; \
+				echo "       you with no dock on your desktop and no new binary."; \
+				echo ""; \
+				echo "       Re-run with PREFIX/BINDIR matching the running binary:"; \
+				echo "         make upgrade PREFIX=$$RUNNING_PREFIX BINDIR=$$RUNNING_BINDIR"; \
+				echo "       (or stop the dock manually and re-run make install)."; \
+				exit 1; \
+			fi; \
+		done; \
 		ARGS_FILE="$$(mktemp)" || exit 1; \
 		trap 'rm -f "$$ARGS_FILE"' EXIT; \
 		for pid in $$RUNNING_PIDS; do \
-			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || exit 1; \
+			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || continue; \
 		done; \
+		$(MAKE) install-bin install-data || exit 1; \
 		echo "Stopping running instance(s): $$RUNNING_PIDS"; \
 		kill $$RUNNING_PIDS 2>/dev/null || true; \
 		sleep 1; \
-		$(MAKE) install-bin install-data || exit 1; \
 		if [ -s "$$ARGS_FILE" ]; then \
 			while IFS= read -r args; do \
 				echo "Restarting with captured args: $$args"; \

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,29 @@ setup-sway:
 # destination and writes a new file; the running process's loaded
 # pages survive intact until the process exits). If install fails,
 # the dock is never killed.
+#
+# PID identity validation (CodeRabbit follow-up): capture
+# `/proc/$PID/stat` field 22 (starttime — clock ticks since boot)
+# alongside each pid at discovery; re-verify before SIGTERM and
+# SIGKILL. Starttime is kernel-authoritative and unique per
+# (pid, boot), so a reused pid with a different process attached
+# gets dropped from the kill list rather than SIGKILLed blindly.
+#
+# SIGKILL escalation + refuse-restart-on-failure (CodeRabbit
+# outside-diff finding): old code did `kill $PIDS || true; sleep 1;
+# restart` — if SIGTERM silently failed or a process ignored it,
+# we'd start a new dock alongside the old one (2 docks; singleton
+# lockfile would prevent the second from staying alive but it's
+# still wrong). Now: after SIGTERM+sleep, check each pid's
+# starttime; still-alive pids get SIGKILL; if any survive SIGKILL
+# the recipe fails BEFORE restart so you never end up with two
+# dock instances fighting for the layer surface.
+#
+# --dump-args failure handling: a failure is only swallowed when
+# the pid has actually disappeared (no `/proc/$PID/exe`). If
+# --dump-args fails on a still-live dock that's a real bug —
+# fail-fast with an explicit error rather than silently killing
+# the dock without capturing its args.
 upgrade: build-release
 	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) $(LEGACY_BIN_NAME) 2>/dev/null | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $$//' || true)"; \
 	if [ -n "$$RUNNING_PIDS" ]; then \
@@ -210,14 +233,60 @@ upgrade: build-release
 			fi; \
 		done; \
 		ARGS_FILE="$$(mktemp)" || exit 1; \
-		trap 'rm -f "$$ARGS_FILE"' EXIT; \
+		RUNNING_INFO="$$(mktemp)" || exit 1; \
+		trap 'rm -f "$$ARGS_FILE" "$$RUNNING_INFO"' EXIT; \
 		for pid in $$RUNNING_PIDS; do \
-			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || continue; \
+			START_TIME="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+			test -n "$$START_TIME" || continue; \
+			if ! target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE"; then \
+				if [ -e "/proc/$$pid/exe" ]; then \
+					echo "ERROR: --dump-args failed for live dock pid $$pid"; \
+					exit 1; \
+				fi; \
+				continue; \
+			fi; \
+			echo "$$pid $$START_TIME" >> "$$RUNNING_INFO"; \
 		done; \
 		$(MAKE) install-bin install-data || exit 1; \
-		echo "Stopping running instance(s): $$RUNNING_PIDS"; \
-		kill $$RUNNING_PIDS 2>/dev/null || true; \
-		sleep 1; \
+		VALIDATED_PIDS=""; \
+		while IFS=' ' read -r pid start_time; do \
+			ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+			if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$start_time" ]; then \
+				VALIDATED_PIDS="$$VALIDATED_PIDS $$pid"; \
+			else \
+				echo "Skipping pid $$pid — no longer our dock (starttime changed or process exited between capture and kill)"; \
+			fi; \
+		done < "$$RUNNING_INFO"; \
+		if [ -n "$$VALIDATED_PIDS" ]; then \
+			echo "Stopping running instance(s):$$VALIDATED_PIDS"; \
+			kill $$VALIDATED_PIDS 2>/dev/null || true; \
+			sleep 1; \
+			STILL_RUNNING=""; \
+			for pid in $$VALIDATED_PIDS; do \
+				START_TIME="$$(grep "^$$pid " "$$RUNNING_INFO" | awk '{print $$2}')"; \
+				ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+				if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ]; then \
+					STILL_RUNNING="$$STILL_RUNNING $$pid"; \
+				fi; \
+			done; \
+			if [ -n "$$STILL_RUNNING" ]; then \
+				echo "Warning: still running after SIGTERM:$$STILL_RUNNING — escalating to SIGKILL"; \
+				kill -9 $$STILL_RUNNING 2>/dev/null || true; \
+				sleep 1; \
+				FINAL_ALIVE=""; \
+				for pid in $$STILL_RUNNING; do \
+					START_TIME="$$(grep "^$$pid " "$$RUNNING_INFO" | awk '{print $$2}')"; \
+					ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+					if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ]; then \
+						FINAL_ALIVE="$$FINAL_ALIVE $$pid"; \
+					fi; \
+				done; \
+				test -z "$$FINAL_ALIVE" || { \
+					echo "ERROR: failed to stop$$FINAL_ALIVE after SIGKILL; refusing to restart while old dock still running"; \
+					exit 1; \
+				}; \
+			fi; \
+		fi; \
 		if [ -s "$$ARGS_FILE" ]; then \
 			while IFS= read -r args; do \
 				echo "Restarting with captured args: $$args"; \

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,15 @@ upgrade: build-release
 		INSTALL_TARGET_REAL="$$(readlink -f "$$INSTALL_TARGET" 2>/dev/null || echo "$$INSTALL_TARGET")"; \
 		for pid in $$RUNNING_PIDS; do \
 			RUNNING_EXE="$$(readlink -f "/proc/$$pid/exe" 2>/dev/null)"; \
-			test -n "$$RUNNING_EXE" || continue; \
+			if [ -z "$$RUNNING_EXE" ]; then \
+				if [ -d "/proc/$$pid" ]; then \
+					echo "ERROR: unable to resolve /proc/$$pid/exe for live dock pid $$pid"; \
+					echo "       (process is alive but its exe symlink is unreadable — refusing to proceed"; \
+					echo "        without install-target validation)"; \
+					exit 1; \
+				fi; \
+				continue; \
+			fi; \
 			if [ "$$RUNNING_EXE" != "$$INSTALL_TARGET_REAL" ]; then \
 				RUNNING_BINDIR="$$(dirname "$$RUNNING_EXE")"; \
 				RUNNING_PREFIX="$$(dirname "$$RUNNING_BINDIR")"; \

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub enum Layer {
 
 /// A macOS-style dock for Hyprland/Sway.
 #[derive(Parser, Debug, Clone)]
-#[command(name = "nwg-dock-hyprland", version, about)]
+#[command(name = "nwg-dock", version, about)]
 pub struct DockConfig {
     /// Alignment in full width/height
     #[arg(short = 'a', long, value_enum, default_value_t = Alignment::Center)]


### PR DESCRIPTION
## Summary

Two fixes surfaced during Phase 5 dogfood ([mac-doc-hyprland#136](https://github.com/jasonherald/mac-doc-hyprland/issues/136)):

- **Commit 1 (#34)**: clap \`#[command(name = \"nwg-dock-hyprland\")]\` still held the old name after the Phase 2 rename, so \`nwg-dock --version\` reported \"nwg-dock-hyprland 0.3.0\". Fixed to \"nwg-dock\".
- **Commit 2 (#35)**: \`make upgrade\` without PREFIX/BINDIR would kill the dock then fail the install on permission denied, leaving the desktop session with no visible dock and no binary update. Added install-target validation before the kill; reordered recipe so install happens before kill (atomicity); deduped pidof output to avoid double-restart under the symlink alias.

## Verified empirically

### \`--version\` after fix

\`\`\`
\$ nwg-dock --version
nwg-dock 0.3.0

\$ nwg-dock-hyprland --version    # via legacy symlink alias
nwg-dock 0.3.0
\`\`\`

### Upgrade failure path

\`\`\`
\$ cd ~/source/nwg-dock && make upgrade
ERROR: running dock (pid 841858) is installed at
         /home/jherald/.cargo/bin/nwg-dock
       but 'make upgrade' would install to
         /usr/local/bin/nwg-dock

       Dock NOT killed — a prefix-mismatched upgrade would leave
       you with no dock on your desktop and no new binary.
...
make: *** [Makefile:185: upgrade] Error 1

\$ pgrep -u "\$USER" -af 'nwg-dock-hyprland'
841858 ... (still running)
\`\`\`

### Upgrade happy path

\`\`\`
\$ make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin
...
Installing binary to /home/jherald/.cargo/bin/nwg-dock
Creating legacy-name symlink: nwg-dock-hyprland → nwg-dock
Installing data assets to /home/jherald/.local/share/nwg-dock-hyprland/
Stopping running instance(s): 1368215           ← single pid (dedupe working)
Restarting with captured args: /home/jherald/.cargo/bin/nwg-dock-hyprland -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c 'nwg-drawer --opacity 88 --pb-auto --pin-indicator'
Upgrade complete.

\$ pgrep -u "\$USER" -af 'nwg-dock'
1420765 /home/jherald/.cargo/bin/nwg-dock-hyprland ...   ← one new dock, args preserved incl nested -c
\`\`\`

### Symlink canonicalization

The dock was launched via \`nwg-dock-hyprland\` (the legacy symlink), but \`/proc/\$pid/exe\` kernel-resolves to the real path \`/home/jherald/.cargo/bin/nwg-dock\`. \`readlink -f\` on both sides of the install-target comparison handles this transparently — no alias-specific logic needed.

### Dedupe fix

Before: \`pidof -c nwg-dock nwg-dock-hyprland\` returned the same pid twice (once per name). After pipeline \`| tr ' ' '\\n' | sort -u | tr '\\n' ' '\`, each pid appears once. Prevents double --dump-args, double kill (harmless), and double setsid respawn (the second one got silently killed by nwg-common's singleton lockfile — harmless but wasteful).

## Test plan
- [x] \`--version\` reports canonical name on both the binary and the symlink
- [x] Failure path aborts without killing the dock
- [x] Happy path installs + restarts with captured args including nested \`-c\`
- [x] Single pid / single restart under the symlink alias (dedupe working)
- [x] \`cargo fmt --check\` + \`cargo clippy --all-targets -- -D warnings\` + \`cargo test --workspace\` all green locally
- [x] CI green
- [ ] CodeRabbit review clean

Related sister PRs: [jasonherald/nwg-notifications#6](https://github.com/jasonherald/nwg-notifications/pull/6), [jasonherald/nwg-drawer#25](https://github.com/jasonherald/nwg-drawer/pull/25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Upgrade now deduplicates symlinked instances, verifies the running binary before replacing, skips processes that disappeared during capture, re-checks start-time before stopping, escalates TERM to KILL if needed, and aborts the upgrade if any target process survives to prevent duplicate instances.

* **Changes**
  * CLI binary name changed from "nwg-dock-hyprland" to "nwg-dock"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->