### PR TITLE
Filter upgrade replay by VALIDATED_PIDS; recheck identity on --dump-args failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,34 +256,34 @@ upgrade: build-release
 				fi; \
 				continue; \
 			fi; \
-			printf "%s\t%s\n" "$$pid" "$$DUMP_OUT" >> "$$ARGS_FILE"; \
-			echo "$$pid $$START_TIME" >> "$$RUNNING_INFO"; \
+			printf "%s\t%s\n" "$$pid" "$$DUMP_OUT" >> "$$ARGS_FILE" || exit 1; \
+			echo "$$pid $$START_TIME" >> "$$RUNNING_INFO" || exit 1; \
 		done; \
 		$(MAKE) install-bin install-data || exit 1; \
 		VALIDATED_PIDS=""; \
 		while IFS=' ' read -r pid start_time; do \
 			ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 			if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$start_time" ]; then \
+				kill "$$pid" 2>/dev/null || true; \
 				VALIDATED_PIDS="$$VALIDATED_PIDS $$pid"; \
 			else \
 				echo "Skipping pid $$pid — no longer our dock (starttime changed or process exited between capture and kill)"; \
 			fi; \
 		done < "$$RUNNING_INFO"; \
 		if [ -n "$$VALIDATED_PIDS" ]; then \
-			echo "Stopping running instance(s):$$VALIDATED_PIDS"; \
-			kill $$VALIDATED_PIDS 2>/dev/null || true; \
+			echo "Sent SIGTERM to:$$VALIDATED_PIDS"; \
 			sleep 1; \
 			STILL_RUNNING=""; \
 			for pid in $$VALIDATED_PIDS; do \
 				START_TIME="$$(grep "^$$pid " "$$RUNNING_INFO" | awk '{print $$2}')"; \
 				ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 				if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ]; then \
+					kill -9 "$$pid" 2>/dev/null || true; \
 					STILL_RUNNING="$$STILL_RUNNING $$pid"; \
 				fi; \
 			done; \
 			if [ -n "$$STILL_RUNNING" ]; then \
-				echo "Warning: still running after SIGTERM:$$STILL_RUNNING — escalating to SIGKILL"; \
-				kill -9 $$STILL_RUNNING 2>/dev/null || true; \
+				echo "Escalated to SIGKILL:$$STILL_RUNNING"; \
 				sleep 1; \
 				FINAL_ALIVE=""; \
 				for pid in $$STILL_RUNNING; do \

--- a/Makefile
+++ b/Makefile
@@ -246,13 +246,17 @@ upgrade: build-release
 		for pid in $$RUNNING_PIDS; do \
 			START_TIME="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
 			test -n "$$START_TIME" || continue; \
-			if ! target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE"; then \
-				if [ -e "/proc/$$pid/exe" ]; then \
+			if ! DUMP_OUT="$$(target/release/$(BIN_NAME) --dump-args "$$pid" 2>/dev/null)"; then \
+				ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+				ACTUAL_EXE="$$(readlink -f "/proc/$$pid/exe" 2>/dev/null || true)"; \
+				if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ] && \
+				   [ "$$ACTUAL_EXE" = "$$INSTALL_TARGET_REAL" ]; then \
 					echo "ERROR: --dump-args failed for live dock pid $$pid"; \
 					exit 1; \
 				fi; \
 				continue; \
 			fi; \
+			printf "%s\t%s\n" "$$pid" "$$DUMP_OUT" >> "$$ARGS_FILE"; \
 			echo "$$pid $$START_TIME" >> "$$RUNNING_INFO"; \
 		done; \
 		$(MAKE) install-bin install-data || exit 1; \
@@ -295,11 +299,13 @@ upgrade: build-release
 				}; \
 			fi; \
 		fi; \
-		if [ -s "$$ARGS_FILE" ]; then \
-			while IFS= read -r args; do \
+		if [ -n "$$VALIDATED_PIDS" ] && [ -s "$$ARGS_FILE" ]; then \
+			for pid in $$VALIDATED_PIDS; do \
+				args="$$(awk -v p="$$pid" 'BEGIN{FS="\t"} $$1==p{sub(/^[^\t]*\t/, ""); print; exit}' "$$ARGS_FILE")"; \
+				test -n "$$args" || continue; \
 				echo "Restarting with captured args: $$args"; \
 				setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
-			done < "$$ARGS_FILE"; \
+			done; \
 		fi; \
 	else \
 		echo "No running instance — installing without restart"; \

--- a/Makefile
+++ b/Makefile
@@ -244,10 +244,10 @@ upgrade: build-release
 		RUNNING_INFO="$$(mktemp)" || exit 1; \
 		trap 'rm -f "$$ARGS_FILE" "$$RUNNING_INFO"' EXIT; \
 		for pid in $$RUNNING_PIDS; do \
-			START_TIME="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+			START_TIME="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 			test -n "$$START_TIME" || continue; \
 			if ! DUMP_OUT="$$(target/release/$(BIN_NAME) --dump-args "$$pid" 2>/dev/null)"; then \
-				ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+				ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 				ACTUAL_EXE="$$(readlink -f "/proc/$$pid/exe" 2>/dev/null || true)"; \
 				if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ] && \
 				   [ "$$ACTUAL_EXE" = "$$INSTALL_TARGET_REAL" ]; then \
@@ -262,7 +262,7 @@ upgrade: build-release
 		$(MAKE) install-bin install-data || exit 1; \
 		VALIDATED_PIDS=""; \
 		while IFS=' ' read -r pid start_time; do \
-			ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+			ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 			if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$start_time" ]; then \
 				VALIDATED_PIDS="$$VALIDATED_PIDS $$pid"; \
 			else \
@@ -276,7 +276,7 @@ upgrade: build-release
 			STILL_RUNNING=""; \
 			for pid in $$VALIDATED_PIDS; do \
 				START_TIME="$$(grep "^$$pid " "$$RUNNING_INFO" | awk '{print $$2}')"; \
-				ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+				ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 				if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ]; then \
 					STILL_RUNNING="$$STILL_RUNNING $$pid"; \
 				fi; \
@@ -288,7 +288,7 @@ upgrade: build-release
 				FINAL_ALIVE=""; \
 				for pid in $$STILL_RUNNING; do \
 					START_TIME="$$(grep "^$$pid " "$$RUNNING_INFO" | awk '{print $$2}')"; \
-					ACTUAL_START="$$(awk '{print $$22}' "/proc/$$pid/stat" 2>/dev/null || true)"; \
+					ACTUAL_START="$$(sed 's/.*) //' "/proc/$$pid/stat" 2>/dev/null | awk '{print $$20}' || true)"; \
 					if [ -n "$$ACTUAL_START" ] && [ "$$ACTUAL_START" = "$$START_TIME" ]; then \
 						FINAL_ALIVE="$$FINAL_ALIVE $$pid"; \
 					fi; \


### PR DESCRIPTION
## Summary

Two follow-up fixes to the \`make upgrade\` target, mirroring [jasonherald/nwg-drawer#25](https://github.com/jasonherald/nwg-drawer/pull/25) round-3 review and [jasonherald/nwg-notifications#7](https://github.com/jasonherald/nwg-notifications/pull/7). Closing two bugs proactively so rabbit doesn't flag them on next pass.

### 1. Replay only pids that survived revalidation

Before: ARGS_FILE held bare args lines; replay ran \`setsid sh -c \"\$args\"\` for every captured line, even if the source pid exited on its own between capture and kill — would spawn a second dock alongside any existing instance.

After: ARGS_FILE stores \`<pid>\\t<args>\`. Replay iterates over VALIDATED_PIDS (the set that survived starttime revalidation through the kill cycle) and looks up each pid's args via awk. Pids that exited on their own don't get replayed.

### 2. Recheck identity before treating --dump-args failure as fatal

Before: on --dump-args failure, fail-fast if \`/proc/\$pid/exe\` exists. But if the original dock exited and the kernel reused its pid, /proc/exe exists but belongs to an unrelated process — false alarm.

After: on --dump-args failure, re-read starttime from \`/proc/\$pid/stat\` AND re-resolve \`/proc/\$pid/exe\`. Only fail-fast if BOTH match the captured values. Mismatch → continue.

## Verified empirically

Dock pid 1834512 → 2160667 with pid-tagged args in ARGS_FILE, VALIDATED_PIDS filter applied at replay, single restart with captured args (including the nested \`-c 'nwg-drawer --opacity 88 --pb-auto --pin-indicator'\`) preserved.

## Test plan
- [x] Happy path: kill + restart with pid-filtered replay
- [x] Captured args correctly stored with pid prefix
- [x] VALIDATED_PIDS filter applied (verified by single restart)
- [x] Symlink-alias canonicalization still works
- [x] CI green
- [ ] CodeRabbit review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the upgrade process to be more robust and quieter when capturing running process information.
  * Enhanced restart logic to better recover and restart services even when initial capture attempts fail, reducing failed upgrades and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->