### PR TITLE
Use destroy() to tear down zombie and orphaned dock windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,13 @@ own repo + crates.io crate.
 
 - crates.io metadata (`description`, `readme`, `keywords`, `categories`,
   `repository`) wired up.
+
+### Fixed
+
+- Reconciliation now uses `destroy()` instead of `close()` to tear down
+  zombie and orphaned dock windows. The dock vetoes every close-request
+  to defeat compositor kill shortcuts (Hyprland `killactive`, `Super+Q`),
+  which made `close()` a no-op for our own teardown paths — old windows
+  survived on top of the freshly-rebuilt ones, producing a visible second
+  dock after `swaylock` unlock and other surface-destruction events
+  (#39).

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -285,7 +285,11 @@ fn remove_zombie_docks(
                     "Rebuilding zombie dock for '{}' (layer-shell surface was destroyed)",
                     name
                 );
-                dock.win.close();
+                // destroy() not close(): see ui::window::dock_close_request_response.
+                // The dock vetoes every close-request to defeat compositor kill
+                // shortcuts, so close() here is a no-op and the old window would
+                // survive on top of the rebuilt one (#39 — double dock after swaylock).
+                dock.win.destroy();
                 false
             } else {
                 true
@@ -413,7 +417,10 @@ fn remove_orphaned_docks(
         per_monitor.borrow_mut().retain(|dock| {
             if &dock.output_name == name {
                 log::info!("Removing dock window for disconnected monitor: {}", name);
-                dock.win.close();
+                // destroy() not close() — the dock's close-request veto would
+                // otherwise leave the orphaned window alive. Same rationale as
+                // remove_zombie_docks above; see #39.
+                dock.win.destroy();
                 false
             } else {
                 true

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -2,11 +2,25 @@ use crate::config::{DockConfig, Layer, Position};
 use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
 
+/// Response the dock returns from every `close-request`.
+///
+/// Always `Propagation::Stop`, so compositor close shortcuts (Hyprland
+/// `killactive`, `Super+Q`, etc.) can't accidentally take the dock down.
+///
+/// Pinned as a named function so the contract has one canonical home and
+/// is unit-testable without a GTK display. The corollary — and the
+/// reason this is worth its own symbol — is that any code path that
+/// genuinely *wants* to tear a dock window down (zombie rebuild, monitor
+/// disconnect; see `listeners::remove_zombie_docks` /
+/// `listeners::remove_orphaned_docks`) must call `destroy()`, not
+/// `close()`, because `close()` is unconditionally vetoed here. See #39.
+pub fn dock_close_request_response() -> gtk4::glib::Propagation {
+    gtk4::glib::Propagation::Stop
+}
+
 /// Configures the main dock window with layer-shell properties.
 pub fn setup_dock_window(win: &gtk4::ApplicationWindow, config: &DockConfig) {
-    // Block compositor close requests (e.g. Hyprland killactive / Super+Q)
-    // so the dock can't be accidentally killed via keyboard shortcut.
-    win.connect_close_request(|_| gtk4::glib::Propagation::Stop);
+    win.connect_close_request(|_| dock_close_request_response());
     win.init_layer_shell();
     win.set_namespace(Some("nwg-dock-hyprland"));
 
@@ -64,5 +78,22 @@ pub fn orientations(config: &DockConfig) -> (gtk4::Orientation, gtk4::Orientatio
         (gtk4::Orientation::Horizontal, gtk4::Orientation::Vertical)
     } else {
         (gtk4::Orientation::Vertical, gtk4::Orientation::Horizontal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the contract that creates issue #39: the dock vetoes every
+    /// `close-request`, which means `close()` is a no-op for our windows.
+    /// If this test is ever changed to expect `Propagation::Proceed`, the
+    /// `destroy()` calls in `listeners::remove_zombie_docks` and
+    /// `listeners::remove_orphaned_docks` can be folded back to `close()` —
+    /// but not before, because the zombie rebuild path would otherwise
+    /// leave the old window alive on top of the freshly-created one.
+    #[test]
+    fn close_request_is_always_vetoed() {
+        assert_eq!(dock_close_request_response(), gtk4::glib::Propagation::Stop);
     }
 }


### PR DESCRIPTION
## Summary

- `dock.win.close()` in `remove_zombie_docks` and `remove_orphaned_docks` was a no-op because every dock window installs a `close-request` handler that always returns `Propagation::Stop` (intentional — blocks compositor kill shortcuts like Hyprland `killactive` / `Super+Q`). The dock object got dropped from `per_monitor` but the underlying `GtkApplicationWindow` stayed alive via remaining `Rc` clones, and a freshly-rebuilt window then layered on top during `add_new_docks`.
- After a `swaylock` cycle the zombie path fires reliably (compositor destroys the layer-shell surface, liveness tick flags `surface().is_none()`, reconciliation runs), which is why the symptom shows up on every unlock.
- Switched both teardown sites to `dock.win.destroy()`, which bypasses the close-request handler. The kill-shortcut protection is unaffected: `close()` is the path the compositor uses; `destroy()` is only ever called from our own reconciliation code.
- Pinned the contract with a named `dock_close_request_response()` helper plus a unit test, so a future change that removed the veto would have to update the test and at the same time be reminded that the `destroy()` calls in `listeners.rs` can be folded back to `close()`.

## Test plan

- [x] `cargo test` (74 passed; new `ui::window::tests::close_request_is_always_vetoed` included)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: rebuild + reinstall + restart on Hyprland, run a swaylock lock/unlock cycle — only one dock returns (previously two)

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved issue where duplicate dock windows appeared and persisted after unlock or surface rebuild events, preventing proper cleanup during reconciliation cycles.
* Enhanced window teardown mechanism to ensure old windows are completely removed before rebuilding dock interface.

## Tests
* Added comprehensive test coverage for window close-request handling to validate expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->