### PR TITLE
chore: bump sonar.projectVersion to 0.4.0

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 
 sonar.projectKey=nwg-dock
 sonar.projectName=nwg-dock
-sonar.projectVersion=0.3.0
+sonar.projectVersion=0.4.0
 
 # Source code location — standalone repo has src/ at root (not crates/*/src/)
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Bump \`sonar-project.properties\` projectVersion from \`0.3.0\` to \`0.4.0\` — catch-up after the 0.4.0 release so the SonarQube dashboard reports against the right line.

No code changes. Local \`make sonar\` against \`https://sonar.aaru.network/dashboard?id=nwg-dock\` already analyzed against this version successfully.

## Test plan

- [ ] CI green
- [ ] Sonar dashboard shows new-code-period anchored to 0.4.0 once next analysis runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.4.0 in SonarQube configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->