### PR TITLE
Idiom sweep: CR-01, 02, 03, 04, 05, 10

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -608,8 +608,10 @@ fn apply_hot_reloadable_changes(
     // Opacity: re-load the override CSS using the canonical default
     // background RGB. Kept in sync with ui::css::load_dock_css.
     if old.opacity != new.opacity {
-        let alpha = f64::from(new.opacity.min(100)) / 100.0;
-        let (r, g, b) = crate::ui::constants::DEFAULT_BG_RGB;
+        use crate::ui::constants::{DEFAULT_BG_RGB, OPACITY_PERCENT_MAX};
+        let alpha =
+            f64::from(new.opacity.min(OPACITY_PERCENT_MAX)) / f64::from(OPACITY_PERCENT_MAX);
+        let (r, g, b) = DEFAULT_BG_RGB;
         let opacity_css =
             format!("window {{ background-color: rgba({r}, {g}, {b}, {alpha:.2}); }}");
         nwg_common::config::css::load_css_override(&opacity_css);

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -659,9 +659,9 @@ fn preserve_restart_fields(source: &DockConfig, target: &mut DockConfig, fields:
             "exclusive" => target.exclusive = source.exclusive,
             // RESTART_REQUIRED_FIELDS is the only source of values for
             // `fields`, so any other label is a programming error.
-            other => log::warn!(
-                "preserve_restart_fields: unknown field '{other}' (programming error)"
-            ),
+            other => {
+                log::warn!("preserve_restart_fields: unknown field '{other}' (programming error)")
+            }
         }
     }
 }
@@ -768,9 +768,7 @@ pub fn notify_user(summary: &str, body: &str) {
         .icon("nwg-dock-hyprland")
         .show()
     {
-        log::warn!(
-            "Failed to send notification ({e}): {summary} — {body}"
-        );
+        log::warn!("Failed to send notification ({e}): {summary} — {body}");
     }
 }
 
@@ -1357,10 +1355,7 @@ mod tests {
                 applied,
             } => {
                 assert_eq!(restart_fields, vec!["multi"]);
-                assert!(
-                    applied.is_empty(),
-                    "expected no applied, got: {applied:?}"
-                );
+                assert!(applied.is_empty(), "expected no applied, got: {applied:?}");
             }
             other => panic!("expected RestartRequired, got {other:?}"),
         }
@@ -1375,10 +1370,7 @@ mod tests {
                 restart_fields,
                 applied,
             } => {
-                assert!(
-                    restart_fields.contains(&"multi"),
-                    "got: {restart_fields:?}"
-                );
+                assert!(restart_fields.contains(&"multi"), "got: {restart_fields:?}");
                 assert!(
                     restart_fields.contains(&"autohide"),
                     "got: {restart_fields:?}"
@@ -1411,10 +1403,7 @@ mod tests {
                 applied,
             } => {
                 // Restart-required field surfaces in the footnote.
-                assert!(
-                    restart_fields.contains(&"multi"),
-                    "got: {restart_fields:?}"
-                );
+                assert!(restart_fields.contains(&"multi"), "got: {restart_fields:?}");
                 assert!(
                     !restart_fields.contains(&"icon-size"),
                     "got: {restart_fields:?}"

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -608,7 +608,7 @@ fn apply_hot_reloadable_changes(
     // Opacity: re-load the override CSS using the canonical default
     // background RGB. Kept in sync with ui::css::load_dock_css.
     if old.opacity != new.opacity {
-        let alpha = (new.opacity.min(100) as f64) / 100.0;
+        let alpha = f64::from(new.opacity.min(100)) / 100.0;
         let (r, g, b) = crate::ui::constants::DEFAULT_BG_RGB;
         let opacity_css =
             format!("window {{ background-color: rgba({r}, {g}, {b}, {alpha:.2}); }}");

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -135,7 +135,7 @@ pub enum ConfigError {
 impl std::fmt::Display for ConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConfigError::ParseError(e) => write!(f, "parse error: {}", e),
+            ConfigError::ParseError(e) => write!(f, "parse error: {e}"),
             ConfigError::InvalidValue {
                 section,
                 key,
@@ -143,10 +143,9 @@ impl std::fmt::Display for ConfigError {
                 error_message,
             } => write!(
                 f,
-                "invalid value for {}.{}: '{}' — expected {}",
-                section, key, error_debug, error_message
+                "invalid value for {section}.{key}: '{error_debug}' — expected {error_message}"
             ),
-            ConfigError::IoError(e) => write!(f, "{}", e),
+            ConfigError::IoError(e) => write!(f, "{e}"),
         }
     }
 }
@@ -210,8 +209,8 @@ pub fn load_config_file(path: &std::path::Path) -> Result<Option<RawConfigFile>,
             ConfigError::InvalidValue {
                 section,
                 key,
-                error_debug: format!("{:?}", inner),
-                error_message: format!("{}", inner),
+                error_debug: format!("{inner:?}"),
+                error_message: format!("{inner}"),
             }
         })
         .map(Some)
@@ -289,7 +288,7 @@ pub fn collect_unknown_keys(value: &toml::Value) -> Vec<String> {
         };
         for (key, _) in section_table {
             if !known_keys.contains(&key.as_str()) {
-                unknowns.push(format!("{}.{}", section_name, key));
+                unknowns.push(format!("{section_name}.{key}"));
             }
         }
     }
@@ -545,7 +544,7 @@ pub fn apply_config_change(
         "Hot-reloading config; applied fields: {:?}, restart-required: {}",
         applied,
         match &result {
-            DiffResult::RestartRequired { restart_fields, .. } => format!("{:?}", restart_fields),
+            DiffResult::RestartRequired { restart_fields, .. } => format!("{restart_fields:?}"),
             _ => "none".to_string(),
         }
     );
@@ -661,8 +660,7 @@ fn preserve_restart_fields(source: &DockConfig, target: &mut DockConfig, fields:
             // RESTART_REQUIRED_FIELDS is the only source of values for
             // `fields`, so any other label is a programming error.
             other => log::warn!(
-                "preserve_restart_fields: unknown field '{}' (programming error)",
-                other
+                "preserve_restart_fields: unknown field '{other}' (programming error)"
             ),
         }
     }
@@ -721,7 +719,7 @@ pub fn print_effective_config(cfg: &DockConfig) -> String {
     toml::to_string_pretty(&raw).unwrap_or_else(|e| {
         // Serializing should never fail for our well-typed schema, but
         // returning a usable string keeps --print-config from panicking.
-        format!("# print_effective_config serialization failed: {}\n", e)
+        format!("# print_effective_config serialization failed: {e}\n")
     })
 }
 
@@ -771,10 +769,7 @@ pub fn notify_user(summary: &str, body: &str) {
         .show()
     {
         log::warn!(
-            "Failed to send notification ({}): {} — {}",
-            e,
-            summary,
-            body
+            "Failed to send notification ({e}): {summary} — {body}"
         );
     }
 }
@@ -843,7 +838,7 @@ where
     }) {
         Ok(w) => w,
         Err(e) => {
-            log::warn!("Failed to create config watcher: {}", e);
+            log::warn!("Failed to create config watcher: {e}");
             return;
         }
     };
@@ -964,7 +959,7 @@ mod tests {
         .unwrap();
         match raw.filters.ignore_classes {
             Some(StringOrList::String(s)) => assert_eq!(s, "steam firefox"),
-            other => panic!("expected String form, got {:?}", other),
+            other => panic!("expected String form, got {other:?}"),
         }
     }
 
@@ -979,7 +974,7 @@ mod tests {
         .unwrap();
         match raw.filters.ignore_classes {
             Some(StringOrList::List(v)) => assert_eq!(v, vec!["steam", "firefox"]),
-            other => panic!("expected List form, got {:?}", other),
+            other => panic!("expected List form, got {other:?}"),
         }
     }
 
@@ -1069,8 +1064,8 @@ mod tests {
     fn config_error_parse_display() {
         let err = toml::from_str::<RawConfigFile>("[behavior\nfoo = 1").expect_err("must fail");
         let ce = ConfigError::ParseError(err);
-        let display = format!("{}", ce);
-        assert!(display.contains("parse error"), "got: {}", display);
+        let display = format!("{ce}");
+        assert!(display.contains("parse error"), "got: {display}");
     }
 
     #[test]
@@ -1081,13 +1076,12 @@ mod tests {
             error_debug: "side".into(),
             error_message: "one of: top, bottom, left, right".into(),
         };
-        let display = format!("{}", ce);
-        assert!(display.contains("layout.position"), "got: {}", display);
-        assert!(display.contains("side"), "got: {}", display);
+        let display = format!("{ce}");
+        assert!(display.contains("layout.position"), "got: {display}");
+        assert!(display.contains("side"), "got: {display}");
         assert!(
             display.contains("top, bottom, left, right"),
-            "got: {}",
-            display
+            "got: {display}"
         );
     }
 
@@ -1095,8 +1089,8 @@ mod tests {
     fn config_error_io_display() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
         let ce = ConfigError::IoError(io_err);
-        let display = format!("{}", ce);
-        assert!(display.contains("missing"), "got: {}", display);
+        let display = format!("{ce}");
+        assert!(display.contains("missing"), "got: {display}");
     }
 
     // ─── load_config_file ──────────────────────────────────────────────────
@@ -1132,7 +1126,7 @@ mod tests {
     fn load_returns_parse_error_on_bad_toml() {
         let f = temp_config("[behavior\nautohide = true");
         let err = load_config_file(f.path()).unwrap_err();
-        assert!(matches!(err, ConfigError::ParseError(_)), "got: {:?}", err);
+        assert!(matches!(err, ConfigError::ParseError(_)), "got: {err:?}");
     }
 
     #[test]
@@ -1149,7 +1143,7 @@ mod tests {
                 assert_eq!(section, "layout");
                 assert_eq!(key, "position");
             }
-            other => panic!("expected InvalidValue, got {:?}", other),
+            other => panic!("expected InvalidValue, got {other:?}"),
         }
     }
 
@@ -1164,8 +1158,7 @@ mod tests {
         let unknowns = collect_unknown_keys(&value);
         assert!(
             unknowns.contains(&"behavior.unknown-typo".to_string()),
-            "got: {:?}",
-            unknowns
+            "got: {unknowns:?}"
         );
 
         let f = temp_config(content);
@@ -1185,8 +1178,7 @@ mod tests {
         let unknowns = collect_unknown_keys(&value);
         assert!(
             unknowns.contains(&"unknown-section".to_string()),
-            "got: {:?}",
-            unknowns
+            "got: {unknowns:?}"
         );
 
         let f = temp_config(content);
@@ -1337,7 +1329,7 @@ mod tests {
             "[launcher]",
             "[filters]",
         ] {
-            assert!(s.contains(header), "expected {} in:\n{}", header, s);
+            assert!(s.contains(header), "expected {header} in:\n{s}");
         }
     }
 
@@ -1367,11 +1359,10 @@ mod tests {
                 assert_eq!(restart_fields, vec!["multi"]);
                 assert!(
                     applied.is_empty(),
-                    "expected no applied, got: {:?}",
-                    applied
+                    "expected no applied, got: {applied:?}"
                 );
             }
-            other => panic!("expected RestartRequired, got {:?}", other),
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 
@@ -1386,17 +1377,15 @@ mod tests {
             } => {
                 assert!(
                     restart_fields.contains(&"multi"),
-                    "got: {:?}",
-                    restart_fields
+                    "got: {restart_fields:?}"
                 );
                 assert!(
                     restart_fields.contains(&"autohide"),
-                    "got: {:?}",
-                    restart_fields
+                    "got: {restart_fields:?}"
                 );
-                assert!(applied.is_empty(), "got: {:?}", applied);
+                assert!(applied.is_empty(), "got: {applied:?}");
             }
-            other => panic!("expected RestartRequired, got {:?}", other),
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 
@@ -1408,7 +1397,7 @@ mod tests {
             DiffResult::Applicable { applied } => {
                 assert!(applied.contains(&"icon-size"));
             }
-            other => panic!("expected Applicable, got {:?}", other),
+            other => panic!("expected Applicable, got {other:?}"),
         }
     }
 
@@ -1424,18 +1413,16 @@ mod tests {
                 // Restart-required field surfaces in the footnote.
                 assert!(
                     restart_fields.contains(&"multi"),
-                    "got: {:?}",
-                    restart_fields
+                    "got: {restart_fields:?}"
                 );
                 assert!(
                     !restart_fields.contains(&"icon-size"),
-                    "got: {:?}",
-                    restart_fields
+                    "got: {restart_fields:?}"
                 );
                 // Hot-reloadable field still applies on the same save.
-                assert!(applied.contains(&"icon-size"), "got: {:?}", applied);
+                assert!(applied.contains(&"icon-size"), "got: {applied:?}");
             }
-            other => panic!("expected RestartRequired, got {:?}", other),
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 
@@ -1465,10 +1452,10 @@ mod tests {
         let b = cfg(&["test", "--mt", "5", "--mb", "10"]);
         match diff_config(&a, &b) {
             DiffResult::Applicable { applied } => {
-                assert!(applied.contains(&"mt"), "got: {:?}", applied);
-                assert!(applied.contains(&"mb"), "got: {:?}", applied);
+                assert!(applied.contains(&"mt"), "got: {applied:?}");
+                assert!(applied.contains(&"mb"), "got: {applied:?}");
             }
-            other => panic!("expected Applicable, got {:?}", other),
+            other => panic!("expected Applicable, got {other:?}"),
         }
     }
 
@@ -1487,7 +1474,7 @@ mod tests {
             DiffResult::Applicable { applied } => {
                 assert!(applied.contains(&"launcher-cmd"));
             }
-            other => panic!("expected Applicable, got {:?}", other),
+            other => panic!("expected Applicable, got {other:?}"),
         }
     }
 
@@ -1504,7 +1491,7 @@ mod tests {
                 assert_eq!(restart_fields, vec!["exclusive"]);
                 assert!(applied.is_empty());
             }
-            other => panic!("expected RestartRequired, got {:?}", other),
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 
@@ -1519,10 +1506,10 @@ mod tests {
                 applied,
             } => {
                 assert_eq!(restart_fields, vec!["multi"]);
-                assert!(applied.contains(&"icon-size"), "got: {:?}", applied);
-                assert!(applied.contains(&"opacity"), "got: {:?}", applied);
+                assert!(applied.contains(&"icon-size"), "got: {applied:?}");
+                assert!(applied.contains(&"opacity"), "got: {applied:?}");
             }
-            other => panic!("expected RestartRequired, got {:?}", other),
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -119,7 +119,7 @@ fn needs_rebuild(state: &Rc<RefCell<DockState>>) -> bool {
 pub fn start_event_listener(
     state: Rc<RefCell<DockState>>,
     rebuild_fn: Rc<dyn Fn()>,
-    compositor: Rc<dyn Compositor>,
+    compositor: &dyn Compositor,
 ) {
     let (sender, receiver) = mpsc::channel::<String>();
     let (ws_sender, ws_receiver) = mpsc::channel::<()>();

--- a/src/events.rs
+++ b/src/events.rs
@@ -93,7 +93,7 @@ fn needs_rebuild(state: &Rc<RefCell<DockState>>) -> bool {
         .map(|c| c.class.clone());
 
     if let Err(e) = state.borrow_mut().refresh_clients() {
-        log::error!("Failed to refresh clients: {}", e);
+        log::error!("Failed to refresh clients: {e}");
         return false;
     }
 
@@ -128,7 +128,7 @@ pub fn start_event_listener(
     let mut stream = match compositor.event_stream() {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Failed to connect to compositor event stream: {}", e);
+            log::error!("Failed to connect to compositor event stream: {e}");
             return;
         }
     };
@@ -149,7 +149,7 @@ pub fn start_event_listener(
                 }
                 Ok(_) => {} // Other events ignored
                 Err(e) => {
-                    log::error!("Compositor event stream error: {}", e);
+                    log::error!("Compositor event stream error: {e}");
                     break;
                 }
             }

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -58,7 +58,7 @@ pub fn setup_pin_watcher(pinned_file: &Path, rebuild: &Rc<dyn Fn()>) {
         }) {
             Ok(w) => w,
             Err(e) => {
-                log::warn!("Pin watcher failed: {}", e);
+                log::warn!("Pin watcher failed: {e}");
                 return;
             }
         };
@@ -288,8 +288,7 @@ fn remove_zombie_docks(
         per_monitor.borrow_mut().retain(|dock| {
             if &dock.output_name == name {
                 log::warn!(
-                    "Rebuilding zombie dock for '{}' (layer-shell surface was destroyed)",
-                    name
+                    "Rebuilding zombie dock for '{name}' (layer-shell surface was destroyed)"
                 );
                 // destroy() not close(): see ui::window::dock_close_request_response.
                 // The dock vetoes every close-request to defeat compositor kill
@@ -371,7 +370,7 @@ fn decide_reconcile(
     // Missing monitor: GDK has a connector we don't have a dock for
     for name in gdk_names {
         if !dock_names.contains(name) {
-            log::debug!("Liveness: missing dock for '{}'", name);
+            log::debug!("Liveness: missing dock for '{name}'");
             return true;
         }
     }
@@ -379,7 +378,7 @@ fn decide_reconcile(
     // Stale dock: we have a dock for a connector GDK doesn't report anymore
     for name in dock_names {
         if !gdk_names.contains(name) {
-            log::debug!("Liveness: stale dock for '{}'", name);
+            log::debug!("Liveness: stale dock for '{name}'");
             return true;
         }
     }
@@ -387,7 +386,7 @@ fn decide_reconcile(
     // Zombie surface: dock object exists but layer-shell surface is gone
     for (name, has_surface) in dock_names.iter().zip(dock_has_surface.iter()) {
         if !has_surface {
-            log::debug!("Liveness: zombie surface for '{}'", name);
+            log::debug!("Liveness: zombie surface for '{name}'");
             return true;
         }
     }
@@ -423,7 +422,7 @@ fn remove_orphaned_docks(
         }
         per_monitor.borrow_mut().retain(|dock| {
             if &dock.output_name == name {
-                log::info!("Removing dock window for disconnected monitor: {}", name);
+                log::info!("Removing dock window for disconnected monitor: {name}");
                 // destroy() not close() — the dock's close-request veto would
                 // otherwise leave the orphaned window alive. Same rationale as
                 // remove_zombie_docks above; see #39.
@@ -449,7 +448,7 @@ fn add_new_docks(
         let Some(gdk_mon) = monitor_map.get(name) else {
             continue;
         };
-        log::info!("Creating dock window for new monitor: {}", name);
+        log::info!("Creating dock window for new monitor: {name}");
         let dock = dock_windows::create_single_dock_window(app, name, gdk_mon, config);
         dock.win.present();
         if config.autohide {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     let cli_config = match DockConfig::from_arg_matches(&matches) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("error: {}", e);
+            eprintln!("error: {e}");
             std::process::exit(2);
         }
     };
@@ -106,14 +106,14 @@ fn main() {
 
     let config_dir = paths::config_dir("nwg-dock-hyprland");
     if let Err(e) = paths::ensure_dir(&config_dir) {
-        log::warn!("Failed to create config dir: {}", e);
+        log::warn!("Failed to create config dir: {e}");
     }
 
     let css_path = config_dir.join(&config.css_file);
     if !css_path.exists() {
         let src = data_home.join("nwg-dock-hyprland/style.css");
         if let Err(e) = paths::copy_file(&src, &css_path) {
-            log::warn!("Error copying default CSS: {}", e);
+            log::warn!("Error copying default CSS: {e}");
         }
     }
 
@@ -175,7 +175,7 @@ fn activate_dock(app: &gtk4::Application, params: &ActivateParams) {
     state.borrow_mut().locked = ui::dock_menu::load_lock_state();
     state.borrow_mut().wm_class_to_desktop_id = build_wm_class_map(&params.app_dirs);
     if let Err(e) = state.borrow_mut().refresh_clients() {
-        log::error!("Couldn't list clients: {}", e);
+        log::error!("Couldn't list clients: {e}");
     }
 
     let monitors = monitor::resolve_monitors(&params.config);
@@ -263,8 +263,8 @@ fn on_config_save(
     let raw = match config_file::load_config_file(path) {
         Ok(r) => r,
         Err(e) => {
-            log::error!("Config reload failed: {}", e);
-            config_file::notify_user("nwg-dock: config error", &format!("{}", e));
+            log::error!("Config reload failed: {e}");
+            config_file::notify_user("nwg-dock: config error", &format!("{e}"));
             return;
         }
     };
@@ -280,8 +280,7 @@ fn on_config_save(
         Ok(c) => c,
         Err(e) => {
             log::error!(
-                "Failed to rebuild CLI baseline from stored ArgMatches: {}",
-                e
+                "Failed to rebuild CLI baseline from stored ArgMatches: {e}"
             );
             return;
         }
@@ -326,8 +325,7 @@ fn auto_detect_launcher(config: &mut DockConfig) {
     let cmd = config.launcher_cmd.split_whitespace().next().unwrap_or("");
     if !cmd.is_empty() && !command_exists(cmd) {
         log::info!(
-            "Launcher command '{}' not found on PATH, hiding launcher",
-            cmd
+            "Launcher command '{cmd}' not found on PATH, hiding launcher"
         );
         config.nolauncher = true;
     }
@@ -347,10 +345,10 @@ fn acquire_singleton_lock(
         Err(existing_pid) => {
             if let Some(pid) = existing_pid {
                 if is_resident {
-                    log::info!("Running instance found (pid {}), terminating...", pid);
+                    log::info!("Running instance found (pid {pid}), terminating...");
                 } else {
                     signals::send_signal_to_pid(pid, signals::sig_toggle());
-                    log::info!("Sent toggle signal to running instance (pid {}), bye!", pid);
+                    log::info!("Sent toggle signal to running instance (pid {pid}), bye!");
                 }
             }
             std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ fn activate_dock(app: &gtk4::Application, params: &ActivateParams) {
     events::start_event_listener(
         Rc::clone(&state),
         Rc::clone(&rebuild),
-        Rc::clone(&params.compositor),
+        params.compositor.as_ref(),
     );
     listeners::setup_pin_watcher(&params.pinned_file, &rebuild);
     listeners::setup_signal_poller(app, &per_monitor, &params.sig_rx);
@@ -279,9 +279,7 @@ fn on_config_save(
     let cli_snapshot = match DockConfig::from_arg_matches(&matches) {
         Ok(c) => c,
         Err(e) => {
-            log::error!(
-                "Failed to rebuild CLI baseline from stored ArgMatches: {e}"
-            );
+            log::error!("Failed to rebuild CLI baseline from stored ArgMatches: {e}");
             return;
         }
     };
@@ -324,9 +322,7 @@ fn auto_detect_launcher(config: &mut DockConfig) {
     }
     let cmd = config.launcher_cmd.split_whitespace().next().unwrap_or("");
     if !cmd.is_empty() && !command_exists(cmd) {
-        log::info!(
-            "Launcher command '{cmd}' not found on PATH, hiding launcher"
-        );
+        log::info!("Launcher command '{cmd}' not found on PATH, hiding launcher");
         config.nolauncher = true;
     }
 }

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -46,3 +46,12 @@ pub const WORKSPACE_ROW_SPACING: i32 = 0;
 /// icon biases the icon button's visual center). See
 /// `ui/workspaces.rs::build_workspace_row` for the per-Position margin.
 pub const INDICATOR_DIVISOR: i32 = 8;
+
+/// Upper bound on the `--opacity 0..=100` CLI/config value. Used to clamp
+/// user input before computing `alpha = opacity / OPACITY_PERCENT_MAX`
+/// for the dock background's CSS `rgba(...)`. Single source of truth
+/// shared by `ui::css::load_dock_css` (cold start) and
+/// `config_file::apply_hot_reloadable_changes` (hot reload) so the two
+/// paths can't drift. Will move alongside the alpha computation when
+/// CR-2026-05-03-17 consolidates the CSS-reload logic into `ui::css`.
+pub const OPACITY_PERCENT_MAX: u8 = 100;

--- a/src/ui/css.rs
+++ b/src/ui/css.rs
@@ -1,4 +1,4 @@
-use super::constants::DEFAULT_BG_RGB;
+use super::constants::{DEFAULT_BG_RGB, OPACITY_PERCENT_MAX};
 use nwg_common::config::css;
 use std::path::Path;
 
@@ -95,7 +95,7 @@ pub fn load_dock_css(css_path: &Path, opacity: u8) {
 
     // Apply user-configurable opacity — overrides embedded default but
     // user CSS file can still override this via hot-reload.
-    let alpha = f64::from(opacity.min(100)) / 100.0;
+    let alpha = f64::from(opacity.min(OPACITY_PERCENT_MAX)) / f64::from(OPACITY_PERCENT_MAX);
     let (r, g, b) = DEFAULT_BG_RGB;
     let opacity_css = format!("window {{ background-color: rgba({r}, {g}, {b}, {alpha:.2}); }}");
     css::load_css_override(&opacity_css);

--- a/src/ui/css.rs
+++ b/src/ui/css.rs
@@ -95,7 +95,7 @@ pub fn load_dock_css(css_path: &Path, opacity: u8) {
 
     // Apply user-configurable opacity — overrides embedded default but
     // user CSS file can still override this via hot-reload.
-    let alpha = opacity.min(100) as f64 / 100.0;
+    let alpha = f64::from(opacity.min(100)) / 100.0;
     let (r, g, b) = DEFAULT_BG_RGB;
     let opacity_css = format!("window {{ background-color: rgba({r}, {g}, {b}, {alpha:.2}); }}");
     css::load_css_override(&opacity_css);

--- a/src/ui/css.rs
+++ b/src/ui/css.rs
@@ -19,7 +19,7 @@ fn gtk4_compat_css() -> String {
     format!(
         r#"
 window {{
-    background-color: rgba({r}, {g}, {b}, {a:.2});
+    background-color: rgba({r}, {g}, {b}, {DEFAULT_BG_ALPHA:.2});
 }}
 .dock-button {{
     min-height: 0;
@@ -82,7 +82,6 @@ window {{
     color: rgba(255, 255, 255, 1.0);
 }}
 "#,
-        a = DEFAULT_BG_ALPHA,
     )
 }
 
@@ -108,23 +107,20 @@ pub fn load_dock_css(css_path: &Path, opacity: u8) {
     let bounce_css = format!(
         "@keyframes dock-bounce {{\
             0%   {{ transform: translateY(0px); }}\
-            30%  {{ transform: translateY(-{h}px); }}\
+            30%  {{ transform: translateY(-{LAUNCH_BOUNCE_HEIGHT_PX}px); }}\
             60%  {{ transform: translateY(0px); }}\
-            78%  {{ transform: translateY({d}px); }}\
+            78%  {{ transform: translateY({LAUNCH_BOUNCE_DIP_PX}px); }}\
             100% {{ transform: translateY(0px); }}\
         }}\
         @keyframes dock-bounce-vertical {{\
             0%   {{ transform: translateX(0px); }}\
-            30%  {{ transform: translateX(-{h}px); }}\
+            30%  {{ transform: translateX(-{LAUNCH_BOUNCE_HEIGHT_PX}px); }}\
             60%  {{ transform: translateX(0px); }}\
-            78%  {{ transform: translateX({d}px); }}\
+            78%  {{ transform: translateX({LAUNCH_BOUNCE_DIP_PX}px); }}\
             100% {{ transform: translateX(0px); }}\
         }}\
-        .dock-launching {{ animation: dock-bounce {dur}ms linear infinite; }}\
-        .dock-launching-vertical {{ animation: dock-bounce-vertical {dur}ms linear infinite; }}",
-        h = LAUNCH_BOUNCE_HEIGHT_PX,
-        d = LAUNCH_BOUNCE_DIP_PX,
-        dur = LAUNCH_BOUNCE_DURATION_MS,
+        .dock-launching {{ animation: dock-bounce {LAUNCH_BOUNCE_DURATION_MS}ms linear infinite; }}\
+        .dock-launching-vertical {{ animation: dock-bounce-vertical {LAUNCH_BOUNCE_DURATION_MS}ms linear infinite; }}",
     );
     css::load_css_from_data(&bounce_css);
 }

--- a/src/ui/dock_menu.rs
+++ b/src/ui/dock_menu.rs
@@ -66,7 +66,7 @@ pub fn load_lock_state() -> bool {
 fn save_lock_state(locked: bool) {
     let path = lock_file_path();
     if let Err(e) = std::fs::write(&path, if locked { "true" } else { "false" }) {
-        log::warn!("Failed to save lock state: {}", e);
+        log::warn!("Failed to save lock state: {e}");
     }
 }
 

--- a/src/ui/dock_menu.rs
+++ b/src/ui/dock_menu.rs
@@ -57,10 +57,7 @@ pub fn show_dock_background_menu(
 /// Loads the lock state from cache.
 pub fn load_lock_state() -> bool {
     let path = lock_file_path();
-    std::fs::read_to_string(path)
-        .ok()
-        .map(|s| s.trim() == "true")
-        .unwrap_or(false) // default: unlocked
+    std::fs::read_to_string(path).is_ok_and(|s| s.trim() == "true") // default: unlocked
 }
 
 fn save_lock_state(locked: bool) {

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -232,9 +232,9 @@ fn unpin_by_drag(
     let mut st = state.borrow_mut();
     if source_index < st.pinned.len() {
         let removed = st.pinned.remove(source_index);
-        log::info!("Unpinned by drag-off: {}", removed);
+        log::info!("Unpinned by drag-off: {removed}");
         if let Err(e) = pinning::save_pinned(&st.pinned, pinned_path) {
-            log::error!("Failed to save pins: {}", e);
+            log::error!("Failed to save pins: {e}");
         }
         drop(st);
         let rebuild = Rc::clone(rebuild);
@@ -267,7 +267,7 @@ fn reorder_pinned(
     st.pinned.insert(insert_at, item);
 
     if let Err(e) = pinning::save_pinned(&st.pinned, pinned_path) {
-        log::error!("Failed to save reordered pins: {}", e);
+        log::error!("Failed to save reordered pins: {e}");
     }
     drop(st);
     let rebuild = Rc::clone(rebuild);

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -109,7 +109,7 @@ pub fn setup_drag_gesture(
             // Only claim after meaningful movement. GTK4's GestureDrag fires
             // drag_update on ANY motion (no built-in threshold), so without
             // this check, a 1px wobble during a click suppresses Button::clicked.
-            let distance = (offset_x * offset_x + offset_y * offset_y).sqrt();
+            let distance = offset_x.hypot(offset_y);
             if distance < DRAG_CLAIM_THRESHOLD {
                 return;
             }

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -74,9 +74,8 @@ pub fn setup_drag_gesture(
             return;
         };
 
-        let (dock_x, dock_y) = match widget.translate_coordinates(&dock_box, start_x, start_y) {
-            Some(coords) => coords,
-            None => return,
+        let Some((dock_x, dock_y)) = widget.translate_coordinates(&dock_box, start_x, start_y) else {
+            return;
         };
 
         // Mark drag pending immediately so event poller/autohide defer rebuilds

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -74,7 +74,8 @@ pub fn setup_drag_gesture(
             return;
         };
 
-        let Some((dock_x, dock_y)) = widget.translate_coordinates(&dock_box, start_x, start_y) else {
+        let Some((dock_x, dock_y)) = widget.translate_coordinates(&dock_box, start_x, start_y)
+        else {
             return;
         };
 

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -326,8 +326,8 @@ fn update_removal_indicator(item: &gtk4::Widget, outside: bool, icon_size: i32) 
 
 /// Returns true if the cursor position is outside the dock box bounds.
 fn is_cursor_outside_dock(dock_box: &gtk4::Box, x: f64, y: f64, vertical: bool) -> bool {
-    let w = dock_box.width() as f64;
-    let h = dock_box.height() as f64;
+    let w = f64::from(dock_box.width());
+    let h = f64::from(dock_box.height());
     if vertical {
         x < -OUTSIDE_MARGIN || x > w + OUTSIDE_MARGIN
     } else {
@@ -351,9 +351,9 @@ fn calculate_drop_index(
         if widget != *dragged && widget.has_css_class("pinned-item") {
             let alloc = widget.allocation();
             let center = if vertical {
-                alloc.y() as f64 + alloc.height() as f64 / 2.0
+                f64::from(alloc.y()) + f64::from(alloc.height()) / 2.0
             } else {
-                alloc.x() as f64 + alloc.width() as f64 / 2.0
+                f64::from(alloc.x()) + f64::from(alloc.width()) / 2.0
             };
             positions.push(center);
         }

--- a/src/ui/hotspot/cursor_poller.rs
+++ b/src/ui/hotspot/cursor_poller.rs
@@ -268,7 +268,7 @@ fn check_hide_timer(
     let mut left = left_at.borrow_mut();
     match *left {
         None => *left = Some(std::time::Instant::now()),
-        Some(when) if when.elapsed().as_millis() >= hide_timeout as u128 => {
+        Some(when) if when.elapsed().as_millis() >= u128::from(hide_timeout) => {
             log::debug!("Cursor left dock area, hiding");
             for dock in docks.borrow().iter() {
                 dock.win.set_visible(false);

--- a/src/ui/hotspot/cursor_poller.rs
+++ b/src/ui/hotspot/cursor_poller.rs
@@ -35,7 +35,7 @@ pub(super) fn start_cursor_poller(
         Rc::new(RefCell::new(match compositor.list_monitors() {
             Ok(m) => m,
             Err(e) => {
-                log::warn!("Initial monitor list failed: {}", e);
+                log::warn!("Initial monitor list failed: {e}");
                 Vec::new()
             }
         }));
@@ -88,7 +88,7 @@ pub(super) fn start_cursor_poller(
                     *count = 0;
                     match compositor.list_monitors() {
                         Ok(m) => *cached_monitors.borrow_mut() = m,
-                        Err(e) => log::debug!("Monitor cache refresh failed: {}", e),
+                        Err(e) => log::debug!("Monitor cache refresh failed: {e}"),
                     }
                 }
             }
@@ -168,14 +168,14 @@ fn fresh_fullscreen_check(ctx: &PollContext<'_>, monitor_name: &str) -> bool {
     let fresh_monitors = match ctx.compositor.list_monitors() {
         Ok(m) => m,
         Err(e) => {
-            log::debug!("Fresh monitor query for fullscreen check failed: {}", e);
+            log::debug!("Fresh monitor query for fullscreen check failed: {e}");
             return false;
         }
     };
     let fresh_clients = match ctx.compositor.list_clients() {
         Ok(c) => c,
         Err(e) => {
-            log::debug!("Fresh client query for fullscreen check failed: {}", e);
+            log::debug!("Fresh client query for fullscreen check failed: {e}");
             return false;
         }
     };
@@ -410,7 +410,7 @@ mod tests {
             .with_active_workspace(
                 WmWorkspace::default()
                     .with_id(active_workspace_id)
-                    .with_name(format!("{}", active_workspace_id)),
+                    .with_name(format!("{active_workspace_id}")),
             )
     }
 
@@ -422,7 +422,7 @@ mod tests {
     fn test_client_on_workspace(monitor_id: i32, fullscreen: bool, workspace_id: i32) -> WmClient {
         // `WmClient` is #[non_exhaustive] — construct via Default + fluent setters.
         WmClient::default()
-            .with_id(format!("0x{}", monitor_id))
+            .with_id(format!("0x{monitor_id}"))
             .with_class("test")
             .with_initial_class("test")
             .with_title("test")
@@ -430,7 +430,7 @@ mod tests {
             .with_workspace(
                 WmWorkspace::default()
                     .with_id(workspace_id)
-                    .with_name(format!("{}", workspace_id)),
+                    .with_name(format!("{workspace_id}")),
             )
             .with_monitor_id(monitor_id)
             .with_fullscreen(fullscreen)

--- a/src/ui/hotspot/hotspot_windows.rs
+++ b/src/ui/hotspot/hotspot_windows.rs
@@ -111,7 +111,7 @@ pub(super) fn start_hotspot_windows(
 
                 if keep_visible {
                     *left = None;
-                } else if when.elapsed().as_millis() >= hide_timeout as u128 {
+                } else if when.elapsed().as_millis() >= u128::from(hide_timeout) {
                     log::debug!("Cursor left dock area, hiding (hotspot mode)");
                     for dock in docks.borrow().iter() {
                         dock.win.set_visible(false);

--- a/src/ui/hotspot/mod.rs
+++ b/src/ui/hotspot/mod.rs
@@ -19,14 +19,14 @@ pub(super) fn show_on_monitor_only_by_name(
 ) {
     let dock_list = docks.borrow();
     if !dock_list.iter().any(|d| d.output_name == target_name) {
-        log::debug!("No dock window for monitor {}", target_name);
+        log::debug!("No dock window for monitor {target_name}");
         return;
     }
 
     for dock in dock_list.iter() {
         dock.win.set_visible(dock.output_name == target_name);
     }
-    log::debug!("Dock shown on monitor {}", target_name);
+    log::debug!("Dock shown on monitor {target_name}");
 }
 
 /// Sets up autohide using the appropriate method for the compositor.

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -106,7 +106,7 @@ pub fn show_context_menu(
         }));
 
         for ws in 1..=config.num_ws {
-            actions_box.append(&action_button(&format!("-> WS {}", ws), &popover, {
+            actions_box.append(&action_button(&format!("-> WS {ws}"), &popover, {
                 let id = id.clone();
                 let comp = Rc::clone(compositor);
                 move || {
@@ -235,7 +235,7 @@ fn action_button(
 fn truncate_title(title: &str, max: usize) -> String {
     if title.chars().count() > max {
         let truncated: String = title.chars().take(max).collect();
-        format!("{}...", truncated)
+        format!("{truncated}...")
     } else {
         title.to_string()
     }

--- a/src/ui/workspaces.rs
+++ b/src/ui/workspaces.rs
@@ -69,9 +69,7 @@ pub fn active_workspace_for_monitor(
         Ok(m) => m,
         Err(e) => {
             log::warn!(
-                "Failed to query monitors for workspace switcher (monitor='{}'): {}",
-                monitor_name,
-                e
+                "Failed to query monitors for workspace switcher (monitor='{monitor_name}'): {e}"
             );
             return None;
         }
@@ -107,7 +105,7 @@ pub fn build_row(
         let n = btn_plan.n;
         btn.connect_clicked(move |_| {
             if let Err(e) = compositor.focus_workspace(n) {
-                log::warn!("Failed to focus workspace {}: {}", n, e);
+                log::warn!("Failed to focus workspace {n}: {e}");
             }
         });
         row.append(&btn);

--- a/tests/print_config.rs
+++ b/tests/print_config.rs
@@ -43,8 +43,8 @@ position = "left"
     );
 
     let out = String::from_utf8(output.stdout).unwrap();
-    assert!(out.contains("icon-size = 96"), "got:\n{}", out);
-    assert!(out.contains(r#"position = "left""#), "got:\n{}", out);
+    assert!(out.contains("icon-size = 96"), "got:\n{out}");
+    assert!(out.contains(r#"position = "left""#), "got:\n{out}");
 }
 
 #[test]
@@ -71,7 +71,7 @@ icon-size = 96
     assert!(output.status.success());
 
     let out = String::from_utf8(output.stdout).unwrap();
-    assert!(out.contains("icon-size = 32"), "got:\n{}", out);
+    assert!(out.contains("icon-size = 32"), "got:\n{out}");
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn print_config_with_no_file_uses_defaults() {
     assert!(output.status.success());
 
     let out = String::from_utf8(output.stdout).unwrap();
-    assert!(out.contains("icon-size = 48"), "got:\n{}", out); // built-in default
+    assert!(out.contains("icon-size = 48"), "got:\n{out}"); // built-in default
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR 1 of the post-0.4.0 code-refinement rollout (epic #70). Six mechanical idiom polish fixes from the merged code-review doc, one commit per CR for clean review and audit:

- **#46 / CR-01** — Inline format args in \`format!\`/log macros (~88 sites; \`clippy --fix\` of \`uninlined_format_args\`).
- **#47 / CR-02** — Replace \`as\` with \`Type::from(...)\` for infallible widening casts (\`u8→f64\`, \`u64→u128\`, \`i32→f64\`). Lossy \`usize→i32\` casts in \`scale_icon_size\` deliberately untouched (covered by #66 / CR-21).
- **#48 / CR-03** — \`f64::hypot\` in place of hand-rolled hypotenuse in \`drag.rs\`.
- **#49 / CR-04** — \`Result::is_ok_and\` instead of \`read_to_string(...).ok().map(...).unwrap_or(false)\` in \`dock_menu::load_lock_state\`.
- **#50 / CR-05** — Convert the final \`match\` in \`drag::connect_drag_begin\`'s let-else ladder to \`let-else\` for uniformity.
- **#55 / CR-10** — \`start_event_listener\` now takes \`compositor: &dyn Compositor\` (Rust API Guidelines: minimum borrow). Callsite drops the unnecessary \`Rc::clone\` and passes \`params.compositor.as_ref()\`.

Source: [\`docs/code-review/2026-05-03-comprehensive.md\`](https://github.com/jasonherald/nwg-dock/blob/main/docs/code-review/2026-05-03-comprehensive.md). Each commit message references its CR-ID; the doc has the full \"why this matters\" + acceptance criteria for each.

## Verification

- \`cargo build --release\` ✅
- \`cargo test\` ✅ (135 unit + 4 integration, 0 failures)
- \`cargo clippy --all-targets\` ✅ (zero warnings — repo's standing bar)
- \`cargo fmt --all -- --check\` ✅
- Local \`make upgrade\` smoke-tested by the maintainer: pinned launches, right-click menus, drag-to-reorder, drag-to-unpin, workspace switcher, autohide — all clean, no regressions.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, audit, codeql, CodeRabbit)
- [x] Reviewer eyeball on the CR-01 auto-fix diff for any non-mechanical change (none expected)
- [x] Reviewer eyeball on the CR-10 callsite for clean \`as_ref()\` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized log and error message formatting across startup, config, event, and UI paths.
  * Reduced unnecessary cloning in event listener startup to improve runtime efficiency.
  * Normalized numeric and coordinate computations used by drag, layout, and animation logic.

* **UI**
  * Consistent opacity handling and CSS generation for window and dock visuals.
  * Minor improvements to drag responsiveness and hide-timer behavior.

* **Code Quality**
  * Simplified lock-state persistence and updated tests to match new message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->