### PR TITLE
Cleanup polish: CR-06, 11, 12, 14, 15

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -641,7 +641,7 @@ fn apply_hot_reloadable_changes(
             // we don't need the handle (the existing watcher still owns
             // the original provider), and load_css logs internally on
             // failure rather than returning a Result.
-            let _provider = nwg_common::config::css::load_css(&new_css_path);
+            nwg_common::config::css::load_css(&new_css_path);
         }
     }
 }

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -6,7 +6,6 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
 use notify::{RecursiveMode, Watcher};
-use nwg_common::compositor::Compositor;
 use nwg_common::signals::WindowCommand;
 use std::cell::{Cell, RefCell};
 use std::path::Path;
@@ -15,7 +14,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 /// Delay before hiding dock windows after initial present (allows GTK to render).
-const AUTOHIDE_INITIAL_DELAY: Duration = Duration::from_millis(500);
+pub(crate) const AUTOHIDE_INITIAL_DELAY: Duration = Duration::from_millis(500);
 
 /// Interval for the dock liveness tick — detects missed monitor hotplug events,
 /// zombie layer-shell surfaces (DPMS/lock cycles), and drift between expected
@@ -117,27 +116,6 @@ pub(crate) fn setup_signal_poller(
         }
         glib::ControlFlow::Continue
     });
-}
-
-/// Sets up autohide: hides dock windows after initial show,
-/// then starts the appropriate autohide mechanism for the compositor.
-/// Returns a `HotspotContext` for Sway (used by reconciliation to create
-/// hotspot windows for hotplugged monitors).
-pub(crate) fn setup_autohide(
-    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
-    config: &DockConfig,
-    state: &Rc<RefCell<DockState>>,
-    compositor: &Rc<dyn Compositor>,
-    app: &gtk4::Application,
-) -> Option<Rc<crate::ui::hotspot::HotspotContext>> {
-    for dock in per_monitor.borrow().iter() {
-        let win = dock.win.clone();
-        glib::timeout_add_local_once(AUTOHIDE_INITIAL_DELAY, move || {
-            win.set_visible(false);
-        });
-    }
-
-    crate::ui::hotspot::setup_autohide(per_monitor, config, state, compositor, app)
 }
 
 /// Watches for GDK display monitor changes and reconciles dock windows.

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,7 +380,6 @@ fn build_wm_class_map(app_dirs: &[PathBuf]) -> HashMap<String, String> {
                 .to_string();
             match nwg_common::desktop::entry::parse_desktop_file(&id, &path) {
                 Ok(entry) if !entry.startup_wm_class.is_empty() => {
-                    map.insert(entry.startup_wm_class.clone(), id.clone());
                     map.insert(entry.startup_wm_class.to_lowercase(), id);
                 }
                 Ok(_) => {} // no StartupWMClass — skip

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn activate_dock(app: &gtk4::Application, params: &ActivateParams) {
     }
 
     let hotspot_ctx = if params.config.autohide {
-        listeners::setup_autohide(
+        ui::hotspot::setup_autohide(
             &per_monitor,
             &params.config,
             &state,

--- a/src/rebuild.rs
+++ b/src/rebuild.rs
@@ -142,11 +142,5 @@ fn schedule_surface_reset(win: &gtk4::ApplicationWindow) {
 /// layer-shell surface reset only when actually needed (see issue #62 fix
 /// in `rebuild_one_dock`).
 fn count_children(parent: &gtk4::Box) -> usize {
-    let mut n = 0;
-    let mut child = parent.first_child();
-    while let Some(w) = child {
-        n += 1;
-        child = w.next_sibling();
-    }
-    n
+    crate::ui::widgets::children(parent).count()
 }

--- a/src/ui/dock_box.rs
+++ b/src/ui/dock_box.rs
@@ -324,12 +324,5 @@ fn apply_launching_class(item_box: &gtk4::Box, app_id: &str, ctx: &DockContext) 
 
 /// Finds the Button widget inside a dock item box (which may also contain an indicator).
 fn find_child_button(item_box: &gtk4::Box) -> Option<gtk4::Button> {
-    let mut child = item_box.first_child();
-    while let Some(widget) = child {
-        if let Ok(btn) = widget.clone().downcast::<gtk4::Button>() {
-            return Some(btn);
-        }
-        child = widget.next_sibling();
-    }
-    None
+    crate::ui::widgets::children(item_box).find_map(|w| w.downcast::<gtk4::Button>().ok())
 }

--- a/src/ui/dock_box.rs
+++ b/src/ui/dock_box.rs
@@ -64,9 +64,8 @@ fn is_class_represented(class: &str, items: &[String], wm_map: &HashMap<String, 
         return true;
     }
     // WMClass → desktop ID mapping (e.g. "com.billz.app" → "billz")
-    if let Some(desktop_id) = wm_map
-        .get(class)
-        .or_else(|| wm_map.get(&class.to_lowercase()))
+    // Keys are stored lowercased at insert time, so always query with a lowercased key.
+    if let Some(desktop_id) = wm_map.get(&class.to_lowercase())
         && items.iter().any(|i| i.eq_ignore_ascii_case(desktop_id))
     {
         return true;

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -341,22 +341,20 @@ fn calculate_drop_index(
     vertical: bool,
     dragged: &gtk4::Widget,
 ) -> usize {
-    let mut positions = Vec::new();
-    let mut child = dock_box.first_child();
-
-    while let Some(widget) = child {
-        // Skip the dragged item and non-pinned items
-        if widget != *dragged && widget.has_css_class("pinned-item") {
-            let alloc = widget.allocation();
-            let center = if vertical {
+    // Uses the children iterator but needs a filter predicate (skip dragged + non-pinned)
+    // and reads allocation data per child — slightly richer than a plain find_map, but
+    // the traversal itself benefits from the shared helper.
+    let positions: Vec<f64> = crate::ui::widgets::children(dock_box)
+        .filter(|w| w != dragged && w.has_css_class("pinned-item"))
+        .map(|w| {
+            let alloc = w.allocation();
+            if vertical {
                 f64::from(alloc.y()) + f64::from(alloc.height()) / 2.0
             } else {
                 f64::from(alloc.x()) + f64::from(alloc.width()) / 2.0
-            };
-            positions.push(center);
-        }
-        child = widget.next_sibling();
-    }
+            }
+        })
+        .collect();
 
     for (i, &center) in positions.iter().enumerate() {
         if coord < center {

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -341,9 +341,6 @@ fn calculate_drop_index(
     vertical: bool,
     dragged: &gtk4::Widget,
 ) -> usize {
-    // Uses the children iterator but needs a filter predicate (skip dragged + non-pinned)
-    // and reads allocation data per child — slightly richer than a plain find_map, but
-    // the traversal itself benefits from the shared helper.
     let positions: Vec<f64> = crate::ui::widgets::children(dock_box)
         .filter(|w| w != dragged && w.has_css_class("pinned-item"))
         .map(|w| {

--- a/src/ui/hotspot/mod.rs
+++ b/src/ui/hotspot/mod.rs
@@ -34,6 +34,10 @@ pub(super) fn show_on_monitor_only_by_name(
 /// - Compositors with cursor position IPC (Hyprland): poll cursor position
 /// - Compositors without (Sway): use thin GTK layer-shell hotspot windows
 ///
+/// Hides all dock windows after an initial delay so GTK has time to render
+/// before the first hide. Without this, the dock may appear briefly visible
+/// before autohide takes over.
+///
 /// Returns a `HotspotContext` for the Sway path, which reconciliation uses
 /// to create hotspot windows for hotplugged monitors.
 pub(crate) fn setup_autohide(
@@ -43,6 +47,19 @@ pub(crate) fn setup_autohide(
     compositor: &Rc<dyn Compositor>,
     app: &gtk4::Application,
 ) -> Option<Rc<HotspotContext>> {
+    use gtk4::glib;
+
+    // Hide on initial present so GTK has time to render before the first
+    // autohide kick. Without this delay, the dock surface may not yet
+    // have committed a frame and the set_visible(false) can race with
+    // the initial map event.
+    for dock in per_monitor.borrow().iter() {
+        let win = dock.win.clone();
+        glib::timeout_add_local_once(crate::listeners::AUTOHIDE_INITIAL_DELAY, move || {
+            win.set_visible(false);
+        });
+    }
+
     if compositor.supports_cursor_position() {
         cursor_poller::start_cursor_poller(per_monitor, state, compositor);
         None

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -87,21 +87,27 @@ pub(crate) fn show_context_menu(
             let id = id.clone();
             let comp = Rc::clone(compositor);
             move || {
-                let _ = comp.close_window(&id); // Best-effort: window may have closed
+                if let Err(e) = comp.close_window(&id) {
+                    log::debug!("close_window failed for '{id}': {e}"); // Best-effort: window may have closed
+                }
             }
         }));
         actions_box.append(&action_button("Toggle Floating", &popover, {
             let id = id.clone();
             let comp = Rc::clone(compositor);
             move || {
-                let _ = comp.toggle_floating(&id); // Best-effort: window may have closed
+                if let Err(e) = comp.toggle_floating(&id) {
+                    log::debug!("toggle_floating failed for '{id}': {e}"); // Best-effort: window may have closed
+                }
             }
         }));
         actions_box.append(&action_button("Fullscreen", &popover, {
             let id = id.clone();
             let comp = Rc::clone(compositor);
             move || {
-                let _ = comp.toggle_fullscreen(&id); // Best-effort: window may have closed
+                if let Err(e) = comp.toggle_fullscreen(&id) {
+                    log::debug!("toggle_fullscreen failed for '{id}': {e}"); // Best-effort: window may have closed
+                }
             }
         }));
 
@@ -110,7 +116,9 @@ pub(crate) fn show_context_menu(
                 let id = id.clone();
                 let comp = Rc::clone(compositor);
                 move || {
-                    let _ = comp.move_to_workspace(&id, ws); // Best-effort: window may have closed
+                    if let Err(e) = comp.move_to_workspace(&id, ws) {
+                        log::debug!("move_to_workspace failed for '{id}' ws={ws}: {e}"); // Best-effort: window may have closed
+                    }
                 }
             }));
         }
@@ -139,7 +147,9 @@ pub(crate) fn show_context_menu(
     let comp = Rc::clone(compositor);
     btn.connect_clicked(move |_| {
         for id in &insts {
-            let _ = comp.close_window(id);
+            if let Err(e) = comp.close_window(id) {
+                log::debug!("close_window failed for '{id}': {e}"); // Best-effort: window may have closed
+            }
         }
         p.popdown();
     });
@@ -165,7 +175,13 @@ pub(crate) fn show_context_menu(
         } else {
             pinning::pin_item(&mut s.pinned, &class_str);
         }
-        let _ = pinning::save_pinned(&s.pinned, &pinned_path); // Best-effort: file I/O may fail
+        if let Err(e) = pinning::save_pinned(&s.pinned, &pinned_path) {
+            log::warn!(
+                "Failed to save pinned apps to '{}': {}",
+                pinned_path.display(),
+                e
+            );
+        }
         drop(s);
         p.popdown();
         rebuild_ref();
@@ -196,7 +212,13 @@ pub(crate) fn show_pinned_context_menu(
     btn.connect_clicked(move |_| {
         let mut s = state_ref.borrow_mut();
         pinning::unpin_item(&mut s.pinned, &id);
-        let _ = pinning::save_pinned(&s.pinned, &pinned_path); // Best-effort: file I/O may fail
+        if let Err(e) = pinning::save_pinned(&s.pinned, &pinned_path) {
+            log::warn!(
+                "Failed to save pinned apps to '{}': {}",
+                pinned_path.display(),
+                e
+            );
+        }
         drop(s);
         p.popdown();
         rebuild_ref();
@@ -209,11 +231,15 @@ pub(crate) fn show_pinned_context_menu(
 pub(crate) fn focus_window(id: &str, workspace_name: &str, compositor: &dyn Compositor) {
     if workspace_name.starts_with("special") {
         let special_name = workspace_name.strip_prefix("special:").unwrap_or("");
-        let _ = compositor.toggle_special_workspace(special_name); // Best-effort: Hyprland-specific
-    } else {
-        let _ = compositor.focus_window(id); // Best-effort: window may have closed
+        if let Err(e) = compositor.toggle_special_workspace(special_name) {
+            log::debug!("toggle_special_workspace failed for '{special_name}': {e}"); // Best-effort: Hyprland-specific
+        }
+    } else if let Err(e) = compositor.focus_window(id) {
+        log::debug!("focus_window failed for '{id}': {e}"); // Best-effort: window may have closed
     }
-    let _ = compositor.raise_active(); // Best-effort: Sway no-ops this
+    if let Err(e) = compositor.raise_active() {
+        log::debug!("raise_active failed: {e}"); // Best-effort: Sway no-ops this
+    }
 }
 
 /// Creates a flat button that runs an action and closes the popover.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,5 +7,6 @@ pub(crate) mod drag;
 pub(crate) mod hotspot;
 pub(crate) mod launch_bounce;
 pub(crate) mod menus;
+pub(crate) mod widgets;
 pub(crate) mod window;
 pub(crate) mod workspaces;

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,0 +1,16 @@
+//! Small GTK4 widget-tree helpers shared across `ui/`.
+
+use gtk4::prelude::*;
+
+/// Walks the direct children of a GTK widget. Wraps the
+/// `first_child()` / `next_sibling()` linked-list shape into an
+/// `Iterator<Item = gtk4::Widget>` so consumers can use `.count()`,
+/// `.find_map()`, `.filter()`, etc. instead of hand-rolled loops.
+pub(crate) fn children(parent: &impl IsA<gtk4::Widget>) -> impl Iterator<Item = gtk4::Widget> {
+    let mut current = parent.first_child();
+    std::iter::from_fn(move || {
+        let next = current.clone();
+        current = current.as_ref().and_then(|w| w.next_sibling());
+        next
+    })
+}


### PR DESCRIPTION
## Summary

PR 3 of the post-0.4.0 code-refinement rollout (epic #70). Five small-to-medium polish fixes from the comprehensive review doc.

- **#51 / CR-06** — Drop the redundant original-case insert in \`build_wm_class_map\`. The map stored both the original and lowercased form of every \`StartupWMClass\`, but every consumer either compared case-insensitively or fell back to the lowercased form via \`.or_else(|| wm_map.get(&class.to_lowercase()))\`. Now stores only the lowercased key. Only one actual double-probe site existed (\`dock_box::is_class_represented\`); the \`state.rs\` and \`launch_bounce.rs\` lookups iterate by k-v pair so weren't affected. Saves ~half the table size.
- **#56 / CR-11** — Replace 10 silent \`let _ = ...\` discards in \`menus.rs\` with logged variants. Window-IPC sites (close, toggle_floating, toggle_fullscreen, move_to_workspace, toggle_special_workspace, focus_window, raise_active) use \`log::debug!\` — failures there are common (window already gone) and shouldn't pollute warn-level logs. Both \`save_pinned(...)\` callsites escalate to \`log::warn!\` since silent pin-file loss is a real UX hole. Pattern matches the existing usage in \`src/ui/drag.rs\`.
- **#57 / CR-12** — Drop the redundant \`let _provider = nwg_common::config::css::load_css(...)\` binding in the hot-reload CSS path. The comment above already explained the discarded provider; the binding was distracting because \`let _x\` is the same shape used to silence a real Result-discard. Now a bare statement.
- **#59 / CR-14** — Extract \`ui::widgets::children\` iterator helper. Wraps GTK4's \`first_child() / next_sibling()\` linked-list traversal into an \`Iterator<Item = gtk4::Widget>\` so consumers can use \`.count()\`, \`.find_map()\`, \`.filter()\`, etc. instead of hand-rolled loops. Three call sites refactored: \`rebuild::count_children\`, \`dock_box::find_child_button\`, and \`drag::calculate_drop_index\`. \`drag::move_child_to_index\` keeps its hand-rolled loop because it needs a \`Vec\` for indexed access — the helper doesn't simplify it materially.
- **#60 / CR-15** — Inline \`listeners::setup_autohide\` into \`ui::hotspot::setup_autohide\`. Same name in two modules, both pub-crate, both called once — needless indirection. The \"hide on initial present so GTK has time to render\" rationale comment travels with the code. \`AUTOHIDE_INITIAL_DELAY\` was promoted from private \`const\` to \`pub(crate) const\` so the new home can reference it; \`add_new_docks\` (hotplug path) is the second consumer.

Source: [\`docs/code-review/2026-05-03-comprehensive.md\`](https://github.com/jasonherald/nwg-dock/blob/main/docs/code-review/2026-05-03-comprehensive.md). Each commit message references its CR-ID.

## Notable design decisions

- **CR-14 helper applied to \`drag::calculate_drop_index\`.** The doc made this optional (\"if the loop pattern matches\"); the predicate (\`w != dragged && w.has_css_class(\"pinned-item\")\`) and the allocation map fit cleanly into \`.filter().map().collect()\`. Both reviewers signed off on the fit.
- **CR-06 site count: spec said 3, only 1 needed fixing.** Verified pre-PR: \`state::task_instances\` and \`launch_bounce::cancel_matched\` iterate the map by key-value pair to find entries where the value matches; they implicitly hit only the lowercased key now that insert is lowercased-only. Only \`dock_box::is_class_represented\` had the explicit \`get + or_else(get_lowercased)\` shape.
- **\`AUTOHIDE_INITIAL_DELAY\` home.** Both reviewers flagged that CLAUDE.md's canonical home for tunables is \`ui/constants.rs\`, but the constant has a second consumer in \`listeners::add_new_docks\` (the monitor-hotplug path) that argues for staying. Leaving in place; will revisit if a third site appears or the rabbit feels strongly.

## Verification

- \`cargo build --release\` ✅
- \`cargo test\` ✅ (149 unit + 4 integration, 0 failures — no test changes in this PR; unit-test count unchanged from PR 2's tip)
- \`cargo clippy --all-targets\` ✅ (zero warnings)
- \`cargo fmt --all -- --check\` ✅
- Spec compliance review: SPEC_COMPLIANT
- Code quality review: APPROVED (one nit on a self-justifying comment in \`drag.rs\` addressed in commit \`76499c4\`)
- Local \`make upgrade\` smoke-tested by the maintainer: drag-to-reorder, drag-to-unpin, right-click menus (Pin/Unpin/Close/Move-to-workspace), autohide — all clean. Monitor-hotplug path not exercised yet, but no behavior change expected there.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, audit, codeql, CodeRabbit)
- [x] Reviewer eyeball on CR-11's logging tier choice (debug for IPC, warn for save_pinned)
- [x] Reviewer eyeball on the CR-14 \`children()\` helper for soundness (3-child traversal trace already done by quality reviewer)
- [x] Reviewer eyeball on whether \`AUTOHIDE_INITIAL_DELAY\` should move to \`ui/constants.rs\` (both reviewers split on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dock window visibility timing during startup when autohide is enabled.

* **Improvements**
  * Enhanced desktop window matching for more consistent behavior.
  * Refined error handling in menu actions for improved stability.
  * Optimized dock rebuild performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->