### PR TITLE
Events split + concurrency conventions: CR-18, 19, 20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ data/ (or data/nwg-dock-hyprland/ in the monorepo)
 
 ## State borrowing conventions
 
-The dock shares `Rc<RefCell<DockState>>` across ~80+ borrow sites in the UI handlers. The pattern is load-bearing — several handlers explicitly `drop(s)` a `RefMut` before calling `rebuild()`, and the reentrancy guard in `rebuild.rs` (the "glycin pumps the main loop" comment at lines 38-43) exists because nested borrows of state via the rebuild closure caused real crashes in earlier versions.
+The dock shares `Rc<RefCell<DockState>>` across ~80+ borrow sites in the UI handlers. The pattern is load-bearing — several handlers explicitly `drop(s)` a `RefMut` before calling `rebuild()`, and the reentrancy guard in `rebuild.rs` (the `running` / `pending` `Cell<bool>` pair plus the "glycin pumping the main loop" comment inside the rebuild closure) exists because nested borrows of state via the rebuild closure caused real crashes in earlier versions.
 
 **Rules — follow them whenever you add or modify a UI handler:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,20 @@ data/ (or data/nwg-dock-hyprland/ in the monorepo)
 - **Unsafe** — none in this crate; the dock relies on `nwg_common::signals` for the RT-signal unsafe bits.
 - **Tests** — `#[cfg(test)] mod tests` at bottom of file, test behavior not implementation.
 
+## State borrowing conventions
+
+The dock shares `Rc<RefCell<DockState>>` across ~80+ borrow sites in the UI handlers. The pattern is load-bearing — several handlers explicitly `drop(s)` a `RefMut` before calling `rebuild()`, and the reentrancy guard in `rebuild.rs` (the "glycin pumps the main loop" comment at lines 38-43) exists because nested borrows of state via the rebuild closure caused real crashes in earlier versions.
+
+**Rules — follow them whenever you add or modify a UI handler:**
+
+1. **Drop before rebuild.** Any mutator that calls `rebuild()` must `drop(state)` first. The natural placement is `drop(s);` immediately before the `rebuild()` call. Forgetting this produces a `BorrowMutError` panic on a code path that looks harmless in isolation.
+
+2. **Deferred unborrow via `idle_add_local_once`.** When a call site can't drop the borrow synchronously (e.g. the borrow is inside a match arm that calls an async method), schedule the rebuild for the next idle tick with `glib::idle_add_local_once(move || rebuild_fn())` instead of calling it inline.
+
+3. **Read into locals, then drop.** When in doubt: read the values you need out of state into local variables, let the borrow drop (implicitly or with an explicit `drop(s)`), then call methods or fire rebuilds.
+
+**Diagnosing a `BorrowError` or `BorrowMutError` panic:** the call chain is what matters. Find the path that re-enters state (e.g. a GTK signal handler triggered by `rebuild()` that itself borrows state), then apply rule 1 or 2 to the outermost borrow site.
+
 ## Key patterns
 
 ### GTK4 button layout

--- a/src/events.rs
+++ b/src/events.rs
@@ -112,27 +112,17 @@ fn needs_rebuild(state: &Rc<RefCell<DockState>>) -> bool {
     old_classes != new_classes || old_active != new_active
 }
 
-/// Starts a background thread that listens for compositor events
-/// and triggers UI refreshes on the main thread via polling.
-/// Only rebuilds if the client list actually changed (different count
-/// or different set of classes).
-pub(crate) fn start_event_listener(
-    state: Rc<RefCell<DockState>>,
-    rebuild_fn: Rc<dyn Fn()>,
-    compositor: &dyn Compositor,
+/// Spawns the background event-stream drain thread.
+///
+/// Both senders are moved into the closure so the thread owns its end of the
+/// channels for the duration of the process. The thread exits (and drops the
+/// senders) only if the compositor event stream returns an error or either
+/// receiver has already been dropped, which signals the main thread is gone.
+fn spawn_event_thread(
+    mut stream: Box<dyn nwg_common::compositor::WmEventStream>,
+    sender: mpsc::Sender<String>,
+    ws_sender: mpsc::Sender<()>,
 ) {
-    let (sender, receiver) = mpsc::channel::<String>();
-    let (ws_sender, ws_receiver) = mpsc::channel::<()>();
-
-    // Create the event stream on the main thread, then move it to the background
-    let mut stream = match compositor.event_stream() {
-        Ok(s) => s,
-        Err(e) => {
-            log::error!("Failed to connect to compositor event stream: {e}");
-            return;
-        }
-    };
-
     std::thread::spawn(move || {
         loop {
             match stream.next_event() {
@@ -155,14 +145,53 @@ pub(crate) fn start_event_listener(
             }
         }
     });
+}
 
+/// Installs the GLib timer that polls both channels every
+/// `EVENT_POLL_INTERVAL_MS` and triggers a rebuild when either
+/// the client list changed or a workspace event arrived.
+///
+/// Both receivers are moved into the timer closure, keeping the channel ends
+/// alive for the lifetime of the GLib main loop. The poller is structurally
+/// testable with `mpsc::channel` fixtures — actual coverage is in CR-21's scope.
+fn install_event_poller(
+    receiver: mpsc::Receiver<String>,
+    workspace_receiver: mpsc::Receiver<()>,
+    state: Rc<RefCell<DockState>>,
+    rebuild_fn: Rc<dyn Fn()>,
+) {
     glib::timeout_add_local(
         std::time::Duration::from_millis(EVENT_POLL_INTERVAL_MS),
         move || {
-            poll_and_rebuild(&receiver, &ws_receiver, &state, &rebuild_fn);
+            poll_and_rebuild(&receiver, &workspace_receiver, &state, &rebuild_fn);
             glib::ControlFlow::Continue
         },
     );
+}
+
+/// Starts a background thread that listens for compositor events
+/// and triggers UI refreshes on the main thread via polling.
+/// Only rebuilds if the client list actually changed (different count
+/// or different set of classes).
+pub(crate) fn start_event_listener(
+    state: Rc<RefCell<DockState>>,
+    rebuild_fn: Rc<dyn Fn()>,
+    compositor: &dyn Compositor,
+) {
+    let (sender, receiver) = mpsc::channel::<String>();
+    let (ws_sender, ws_receiver) = mpsc::channel::<()>();
+
+    // Create the event stream on the main thread, then move it to the background.
+    let stream = match compositor.event_stream() {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Failed to connect to compositor event stream: {e}");
+            return;
+        }
+    };
+
+    spawn_event_thread(stream, sender, ws_sender);
+    install_event_poller(receiver, ws_receiver, state, rebuild_fn);
 }
 
 #[cfg(test)]

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -72,7 +72,14 @@ pub(crate) fn setup_pin_watcher(pinned_file: &Path, rebuild: &Rc<dyn Fn()>) {
             );
             return;
         }
-        // Block forever — watcher stops if thread exits
+        // Watcher lives until process exit. The thread is parked
+        // indefinitely to keep this closure (and therefore the captured
+        // `tx` sender that `recommended_watcher` holds) alive — if this
+        // thread exited, `tx` would drop, the watcher would close, and
+        // the inotify subscription would be lost. `park()` never returns,
+        // so the thread's `Drop` and the watcher's `Drop` never run; that
+        // matches what we want here (process-lifetime watcher), but means
+        // teardown stories that assume thread exit don't apply.
         std::thread::park();
     });
 


### PR DESCRIPTION
## Summary

PR 4 of the post-0.4.0 code-refinement rollout (epic #70). Three findings — one code refactor, one CLAUDE.md addition, one comment fix.

- **#63 / CR-18** — Split \`events.rs\` background-thread setup from main-thread polling. \`start_event_listener\` was doing three things in 50 lines: create two mpsc channels, spawn a background event-drain thread, install a 100ms GLib timer to poll both channels. Extracted \`spawn_event_thread\` (owns the stream + senders) and \`install_event_poller\` (owns the receivers + state + rebuild closure); \`start_event_listener\` is now a small orchestrator. The poller is now structurally testable with \`mpsc::channel\` fixtures — actual coverage stays in CR-21's testability scope, not added here.
- **#64 / CR-19** — Document state borrowing conventions in CLAUDE.md. Adds a \"State borrowing conventions\" section between *Conventions* and *Key patterns* with three actionable rules: drop before rebuild; deferred unborrow via \`idle_add_local_once\`; read into locals then drop. References the existing reentrancy guard in \`rebuild.rs\` (the \`running\`/\`pending\` \`Cell<bool>\` pair + the \"glycin pumping the main loop\" comment) and gives a diagnostic recipe for \`BorrowError\`/\`BorrowMutError\` panics. Audit-only finding — no code changes; the rules just become visible.
- **#65 / CR-20** — Rewrite the misleading thread-lifecycle comment in \`setup_pin_watcher\`. The old comment said \"Block forever — watcher stops if thread exits\", but \`park()\` never returns, the thread never exits, and the watcher's \`Drop\` therefore never runs. New comment describes the actual lifecycle: process-lifetime watcher, intentional non-termination, and the consequence that teardown-on-thread-exit assumptions don't apply. Comment-only.

Source: [\`docs/code-review/2026-05-03-comprehensive.md\`](https://github.com/jasonherald/nwg-dock/blob/main/docs/code-review/2026-05-03-comprehensive.md). Each commit message references its CR-ID.

## Notable design decisions

- **CR-18 helper signatures.** The spec's proposed signatures for \`spawn_event_thread\` and \`install_event_poller\` returned \`JoinHandle\` and \`SourceId\` respectively. Both implementations return \`()\` — the testability goal (\"poller is now structurally testable with mpsc::channel fixtures\") is met regardless, and no callsite needs the handles. If a future caller needs the \`SourceId\` for tear-down (e.g., to remove the timer on shutdown), promoting the return type is a one-line follow-up.
- **CR-19 placement.** Section sits between \`## Conventions\` and \`## Key patterns\`, exactly where the spec suggested. Reference to \`rebuild.rs\`'s reentrancy guard uses symbol-level pointers (\`running\` / \`pending\`) rather than line numbers — bare line numbers in long-lived docs rot quickly. Initial draft cited line 38-43; corrected post-review to drop the literal line range.
- **CR-20 minimal change.** The principled alternative (restructure to match \`config_file::watch_config_file\`'s GLib-main-loop pattern, saving an OS thread) is filed in the review doc as the optional follow-up. Out of scope for this PR — the comment fix is the *Issue scope (required now)* per the doc's fix-shape convention.

## Verification

- \`cargo build --release\` ✅
- \`cargo test\` ✅ (149 unit + 4 integration, 0 failures — no test changes in this PR)
- \`cargo clippy --all-targets\` ✅ (zero warnings)
- \`cargo fmt --all -- --check\` ✅
- Spec compliance review: SPEC_COMPLIANT (one open issue: CLAUDE.md line-number citation imprecision — fixed in commit \`5b10fc4\`)
- Code quality review: APPROVED (one sub-threshold nit on a \`mut stream\` parameter — reviewer explicitly classified it as below fix-request threshold; left as-is)
- Local \`make upgrade\` smoke-tested by the maintainer: open/close apps (events pipeline), switch workspaces (\`WorkspaceChanged\` arm), active-window highlight (\`ActiveWindowChanged\` arm), pin/unpin via right-click (pin-watcher path) — all clean, no regressions.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, audit, codeql, CodeRabbit)
- [x] Reviewer eyeball on \`spawn_event_thread\` / \`install_event_poller\` split for soundness — particularly the four match arms (ActiveWindowChanged, WorkspaceChanged, other-event no-op, error log + break) preserved verbatim
- [x] Reviewer eyeball on the new CLAUDE.md \"State borrowing conventions\" section — does it actually help a contributor diagnose a future \`BorrowMutError\`?
- [x] Reviewer eyeball on the \`setup_pin_watcher\` comment for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guidance for safe state management and borrowing conventions.
  * Improved documentation of listener thread behavior and lifecycle.

* **Refactor**
  * Reorganized event handling implementation for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->