### PR TITLE
Fillers: CR-09, 21, 22, 23, 24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,11 @@ button.set_child(Some(&vbox));
 ```
 
 Canonical pattern: `ui::buttons::pinned_button` (and similarly `task_button` and
-`launcher_button`) — they all build the `Button + Image + label-or-indicator` shape
-inline. The common shape is not yet extracted into a `ui::widgets::app_icon_button()`
-helper; that's the optional follow-up in the review doc, not a current API.
+`launcher_button`) — they all build the `Button (with Image child) + indicator`
+shape inline. App names live on tooltips via `set_tooltip_text`, not visible
+labels. The common shape is not yet extracted into a
+`ui::widgets::app_icon_button()` helper; that's the optional follow-up in the
+review doc, not a current API.
 
 ### Self-referential rebuild
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,10 @@ vbox.append(&label);
 button.set_child(Some(&vbox));
 ```
 
-Shared helper: `ui::widgets::app_icon_button()`.
+Canonical pattern: `ui::buttons::pinned_button` (and similarly `task_button` and
+`launcher_button`) — they all build the `Button + Image + label-or-indicator` shape
+inline. The common shape is not yet extracted into a `ui::widgets::app_icon_button()`
+helper; that's the optional follow-up in the review doc, not a current API.
 
 ### Self-referential rebuild
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,15 @@
+//! CLI definition and configuration types for nwg-dock.
+//!
+//! [`DockConfig`] is a `clap::Parser` struct that captures all CLI flags.
+//! It is also the merge target for TOML config-file values (see `config_file`
+//! module). The [`Position`], [`Alignment`], and [`Layer`] enums are
+//! `clap::ValueEnum` so clap handles parse + error formatting; they're also
+//! serde-serializable for round-trip through the config file.
+//!
+//! Legacy Go-era single-dash flags (e.g. `-hd`, `-ico`, `-nolauncher`) are
+//! normalised to double-dash form by [`normalize_legacy_flags`] before clap
+//! sees the argument list, so existing autostart lines keep working.
+
 use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,13 @@
 //! CLI definition and configuration types for nwg-dock.
 //!
-//! [`DockConfig`] is a `clap::Parser` struct that captures all CLI flags.
+//! `DockConfig` is a `clap::Parser` struct that captures all CLI flags.
 //! It is also the merge target for TOML config-file values (see `config_file`
-//! module). The [`Position`], [`Alignment`], and [`Layer`] enums are
+//! module). The `Position`, `Alignment`, and `Layer` enums are
 //! `clap::ValueEnum` so clap handles parse + error formatting; they're also
 //! serde-serializable for round-trip through the config file.
 //!
 //! Legacy Go-era single-dash flags (e.g. `-hd`, `-ico`, `-nolauncher`) are
-//! normalised to double-dash form by [`normalize_legacy_flags`] before clap
+//! normalised to double-dash form by `normalize_legacy_flags` before clap
 //! sees the argument list, so existing autostart lines keep working.
 
 use clap::{Parser, ValueEnum};

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,10 @@ pub(crate) struct DockConfig {
     #[arg(short = 'f', long)]
     pub(crate) full: bool,
 
-    /// Quote-delimited, space-separated class list to ignore in the dock
+    /// Space-separated class list to ignore in the dock. Use the TOML
+    /// `[filters] ignore-classes = ["github desktop", ...]` array form
+    /// for class names that contain spaces — the CLI form does not
+    /// support quoted values.
     #[arg(short = 'g', long, default_value = "")]
     pub(crate) ignore_classes: String,
 
@@ -171,8 +174,11 @@ pub(crate) struct DockConfig {
     #[arg(short = 'm', long)]
     pub(crate) multi: bool,
 
-    /// Window background opacity 0-100 (default: 100, fully opaque)
-    #[arg(long, default_value_t = 100)]
+    /// Window background opacity 0-100 (default: 100, fully opaque).
+    /// Values above 100 are rejected at parse time via clap's range
+    /// validator; the runtime `opacity.min(OPACITY_PERCENT_MAX)` clamp
+    /// in `ui::css::reload_opacity` is now belt-and-suspenders.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), default_value_t = 100)]
     pub(crate) opacity: u8,
 
     /// Show a bounce animation on dock icons while an app is launching
@@ -307,6 +313,36 @@ mod tests {
     fn icon_size_default() {
         let config = DockConfig::parse_from(["test"]);
         assert_eq!(config.icon_size, 48);
+    }
+
+    #[test]
+    fn opacity_default_is_100() {
+        let config = DockConfig::parse_from(["test"]);
+        assert_eq!(config.opacity, 100);
+    }
+
+    #[test]
+    fn opacity_accepts_values_in_range() {
+        for v in [0_u8, 1, 50, 99, 100] {
+            let parsed = DockConfig::try_parse_from(["test", "--opacity", &v.to_string()])
+                .unwrap_or_else(|e| panic!("expected --opacity {v} to parse, got: {e}"));
+            assert_eq!(parsed.opacity, v);
+        }
+    }
+
+    #[test]
+    fn opacity_rejects_values_above_100() {
+        // The clap range validator should reject 101..=255 at parse
+        // time. Without this guard, runtime clamping in
+        // `reload_opacity` would silently treat 200 as 100.
+        let result = DockConfig::try_parse_from(["test", "--opacity", "101"]);
+        assert!(
+            result.is_err(),
+            "--opacity 101 should fail at parse time, got: {:?}",
+            result.map(|c| c.opacity)
+        );
+        let result = DockConfig::try_parse_from(["test", "--opacity", "200"]);
+        assert!(result.is_err(), "--opacity 200 should fail at parse time");
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-//! [`DockContext`] — the recurring bundle passed to every dock UI builder.
+//! `DockContext` — the recurring bundle passed to every dock UI builder.
 //!
 //! Bundles the references needed on every rebuild (`config`, `state`,
 //! `data_home`, `pinned_file`, `rebuild`, `compositor`) into a single
@@ -6,7 +6,7 @@
 //! "DockContext" convention: use this whenever you'd otherwise need more than
 //! two or three of its fields as separate arguments.
 //!
-//! Distinct from [`crate::main::DockBootstrap`], which is the startup-only
+//! Distinct from `DockBootstrap` (in `src/main.rs`), which is the startup-only
 //! bundle used once during `connect_activate`. `DockContext` is reconstructed
 //! on every rebuild from the live config snapshot in `DockState`.
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,15 @@
+//! [`DockContext`] — the recurring bundle passed to every dock UI builder.
+//!
+//! Bundles the references needed on every rebuild (`config`, `state`,
+//! `data_home`, `pinned_file`, `rebuild`, `compositor`) into a single
+//! parameter so UI functions don't take 6+ individual refs. Per CLAUDE.md's
+//! "DockContext" convention: use this whenever you'd otherwise need more than
+//! two or three of its fields as separate arguments.
+//!
+//! Distinct from [`crate::main::DockBootstrap`], which is the startup-only
+//! bundle used once during `connect_activate`. `DockContext` is reconstructed
+//! on every rebuild from the live config snapshot in `DockState`.
+
 use crate::config::DockConfig;
 use crate::state::DockState;
 use nwg_common::compositor::Compositor;

--- a/src/dock_windows.rs
+++ b/src/dock_windows.rs
@@ -1,3 +1,13 @@
+//! Per-monitor dock window creation and monitor-diff utilities.
+//!
+//! [`MonitorDock`] bundles each dock window with its stable output connector
+//! name and a small amount of rebuild-tracking state (`prev_item_count` for
+//! the shrink-only layer-shell surface reset). [`create_dock_windows`] is
+//! called at cold start; [`create_single_dock_window`] is reused by the
+//! monitor hotplug reconciliation path in `listeners.rs` when new monitors
+//! appear or zombie surfaces need rebuilding. [`compute_monitor_diff`] is a
+//! pure helper that computes add/remove sets from two name lists.
+
 use crate::config::DockConfig;
 use crate::ui;
 use gtk4::prelude::*;

--- a/src/dock_windows.rs
+++ b/src/dock_windows.rs
@@ -1,11 +1,11 @@
 //! Per-monitor dock window creation and monitor-diff utilities.
 //!
-//! [`MonitorDock`] bundles each dock window with its stable output connector
+//! `MonitorDock` bundles each dock window with its stable output connector
 //! name and a small amount of rebuild-tracking state (`prev_item_count` for
-//! the shrink-only layer-shell surface reset). [`create_dock_windows`] is
-//! called at cold start; [`create_single_dock_window`] is reused by the
+//! the shrink-only layer-shell surface reset). `create_dock_windows` is
+//! called at cold start; `create_single_dock_window` is reused by the
 //! monitor hotplug reconciliation path in `listeners.rs` when new monitors
-//! appear or zombie surfaces need rebuilding. [`compute_monitor_diff`] is a
+//! appear or zombie surfaces need rebuilding. `compute_monitor_diff` is a
 //! pure helper that computes add/remove sets from two name lists.
 
 use crate::config::DockConfig;

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,18 @@
+//! Compositor event stream → smart rebuild.
+//!
+//! Spawns a background thread (`spawn_event_thread`) that drains the
+//! compositor's `WmEventStream`, then installs a GLib timer (`install_event_poller`)
+//! that polls both channels every 100 ms on the main thread. The split keeps
+//! blocking IPC off the GTK main loop while staying compatible with GTK's
+//! single-threaded object model.
+//!
+//! `WmEvent::WorkspaceChanged` bypasses the client-list diff: switching
+//! workspaces doesn't change the client set, but the workspace switcher row
+//! needs to redraw. All other events go through `needs_rebuild`, which
+//! re-queries the compositor and compares old vs new class lists before
+//! deciding to fire a rebuild (avoids spurious rebuilds on focus-only events).
+//! Rebuilds are deferred during an active drag via `state.rebuild_pending`.
+
 use crate::state::DockState;
 use gtk4::glib;
 use nwg_common::compositor::{Compositor, WmEvent};

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -1,3 +1,18 @@
+//! Process-lifetime listeners: pin-file watcher, signal poller, and monitor reconciliation.
+//!
+//! [`setup_pin_watcher`] spawns an inotify-backed thread that watches the
+//! shared pin file (`~/.cache/mac-dock-pinned`) for writes by `nwg-drawer` or
+//! other tools. The watcher thread parks indefinitely — it is a process-
+//! lifetime subscription and is intentionally never joined or torn down.
+//!
+//! [`setup_signal_poller`] installs a GLib timer that drains SIGRTMIN+1/2/3
+//! commands (show / hide / toggle / quit) delivered via `nwg_common::signals`.
+//!
+//! [`setup_monitor_watcher`] and [`setup_liveness_tick`] detect monitor
+//! topology changes (hotplug / DPMS / lock cycles) and call
+//! `reconcile_monitors` to add, remove, or rebuild dock windows as needed.
+//! The liveness tick fires every 2 s as a backstop for missed hotplug events.
+
 use crate::config::DockConfig;
 use crate::dock_windows::{self, MonitorDock};
 use crate::monitor;

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -1,14 +1,14 @@
 //! Process-lifetime listeners: pin-file watcher, signal poller, and monitor reconciliation.
 //!
-//! [`setup_pin_watcher`] spawns an inotify-backed thread that watches the
+//! `setup_pin_watcher` spawns an inotify-backed thread that watches the
 //! shared pin file (`~/.cache/mac-dock-pinned`) for writes by `nwg-drawer` or
 //! other tools. The watcher thread parks indefinitely — it is a process-
 //! lifetime subscription and is intentionally never joined or torn down.
 //!
-//! [`setup_signal_poller`] installs a GLib timer that drains SIGRTMIN+1/2/3
+//! `setup_signal_poller` installs a GLib timer that drains SIGRTMIN+1/2/3
 //! commands (show / hide / toggle / quit) delivered via `nwg_common::signals`.
 //!
-//! [`setup_monitor_watcher`] and [`setup_liveness_tick`] detect monitor
+//! `setup_monitor_watcher` and `setup_liveness_tick` detect monitor
 //! topology changes (hotplug / DPMS / lock cycles) and call
 //! `reconcile_monitors` to add, remove, or rebuild dock windows as needed.
 //! The liveness tick fires every 2 s as a backstop for missed hotplug events.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@
 //!
 //! Parses CLI args (via `config.rs`), merges the TOML config file, acquires
 //! the singleton lock, sets up GTK4, and wires `connect_activate`. The two
-//! coordination types are [`DockBootstrap`] (startup-only refs bundled for
-//! `activate_dock`) and [`crate::context::DockContext`] (the smaller recurring
-//! bag passed on every rebuild). After `activate_dock` returns, the GLib main
-//! loop drives everything; this file has no further role.
+//! coordination types are `DockBootstrap` (startup-only refs bundled for
+//! `activate_dock`) and `DockContext` (in `src/context.rs` — the smaller
+//! recurring bag passed on every rebuild). After `activate_dock` returns,
+//! the GLib main loop drives everything; this file has no further role.
 
 mod config;
 mod config_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() {
         .application_id("com.mac-dock.hyprland")
         .build();
 
-    let bootstrap = Rc::new(ActivateParams {
+    let bootstrap = Rc::new(DockBootstrap {
         css_path: Rc::new(css_path),
         config: Rc::new(config),
         matches: Rc::new(matches),
@@ -144,12 +144,21 @@ fn main() {
     app.run_with_args::<String>(&[]);
 }
 
-/// Bundles everything `activate_dock` needs from `main()` so the
-/// signature stays at one parameter (per CLAUDE.md "never pass 7+
-/// individual refs"). Built once in `main`, cloned on each
-/// `connect_activate` callback. Distinct from `DockContext` (which
-/// covers the rebuild path's narrower needs).
-struct ActivateParams {
+/// Cold-start bootstrap data — the references and handles needed
+/// once during `connect_activate` to wire up the dock. Distinct
+/// from `DockContext` (in `src/context.rs`), which is the smaller
+/// recurring bag the rebuild path operates on. Fields here that
+/// don't appear in `DockContext` are startup-only: `css_path` is
+/// applied once at cold start, `matches` is preserved for hot-
+/// reload's `was_set_on_cli` checks, `app_dirs` and `sig_rx` are
+/// consumed by listeners that run for the process lifetime.
+///
+/// The two structs share `config`, `compositor`, `pinned_file`,
+/// and `data_home` because both lifecycles need them — that overlap
+/// is intentional. The follow-up to fold `DockBootstrap` into
+/// holding a `DockContext` sub-struct is filed as a separate epic
+/// task.
+struct DockBootstrap {
     css_path: Rc<std::path::PathBuf>,
     config: Rc<DockConfig>,
     matches: Rc<clap::ArgMatches>,
@@ -161,7 +170,7 @@ struct ActivateParams {
 }
 
 /// Sets up the dock UI: state, monitors, windows, rebuild function, and listeners.
-fn activate_dock(app: &gtk4::Application, params: &ActivateParams) {
+fn activate_dock(app: &gtk4::Application, params: &DockBootstrap) {
     ui::css::load_dock_css(&params.css_path, params.config.opacity);
     let _hold = app.hold();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,12 @@
+//! Entry point and cold-start orchestration for nwg-dock.
+//!
+//! Parses CLI args (via `config.rs`), merges the TOML config file, acquires
+//! the singleton lock, sets up GTK4, and wires `connect_activate`. The two
+//! coordination types are [`DockBootstrap`] (startup-only refs bundled for
+//! `activate_dock`) and [`crate::context::DockContext`] (the smaller recurring
+//! bag passed on every rebuild). After `activate_dock` returns, the GLib main
+//! loop drives everything; this file has no further role.
+
 mod config;
 mod config_file;
 mod context;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,3 +1,12 @@
+//! Monitor resolution: maps `--output` config to GDK monitor handles.
+//!
+//! [`resolve_monitors`] is the normal entry point; it logs a warning if the
+//! named output isn't found and falls back to all monitors. [`resolve_monitors_quiet`]
+//! is the same logic without the warning, used by the liveness tick in
+//! `listeners.rs` to avoid spamming the log every 2 s when `--output` targets
+//! a temporarily unavailable connector. Both variants call `resolve_monitors_inner`,
+//! which builds the connector→`gdk::Monitor` map via `map_outputs_by_connector`.
+
 use gtk4::gdk;
 use gtk4::prelude::*;
 use std::collections::HashMap;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,7 +1,7 @@
 //! Monitor resolution: maps `--output` config to GDK monitor handles.
 //!
-//! [`resolve_monitors`] is the normal entry point; it logs a warning if the
-//! named output isn't found and falls back to all monitors. [`resolve_monitors_quiet`]
+//! `resolve_monitors` is the normal entry point; it logs a warning if the
+//! named output isn't found and falls back to all monitors. `resolve_monitors_quiet`
 //! is the same logic without the warning, used by the liveness tick in
 //! `listeners.rs` to avoid spamming the log every 2 s when `--output` targets
 //! a temporarily unavailable connector. Both variants call `resolve_monitors_inner`,

--- a/src/rebuild.rs
+++ b/src/rebuild.rs
@@ -1,6 +1,6 @@
 //! Self-referential rebuild closure for the dock UI.
 //!
-//! [`create_rebuild_fn`] returns an `Rc<dyn Fn()>` that rebuilds every
+//! `create_rebuild_fn` returns an `Rc<dyn Fn()>` that rebuilds every
 //! monitor's dock content. The closure needs to pass *itself* to each button
 //! (so buttons can trigger a rebuild on pin/unpin), which would create an
 //! `Rc` cycle. The cycle is broken with a `Weak` reference stored in a

--- a/src/rebuild.rs
+++ b/src/rebuild.rs
@@ -1,3 +1,18 @@
+//! Self-referential rebuild closure for the dock UI.
+//!
+//! [`create_rebuild_fn`] returns an `Rc<dyn Fn()>` that rebuilds every
+//! monitor's dock content. The closure needs to pass *itself* to each button
+//! (so buttons can trigger a rebuild on pin/unpin), which would create an
+//! `Rc` cycle. The cycle is broken with a `Weak` reference stored in a
+//! `Rc<RefCell<Weak<dyn Fn()>>>` holder; buttons upgrade the `Weak` at
+//! call time.
+//!
+//! A `running` / `pending` `Cell<bool>` pair guards against reentrancy:
+//! glycin's icon loading uses D-Bus and can pump the GTK main loop, which
+//! may let a timer or event fire `rebuild_fn` while a build is already in
+//! flight. The guard turns recursive calls into a flag and re-runs once the
+//! outer build finishes, rather than nesting rebuilds that leave ghost widgets.
+
 use crate::context::DockContext;
 use crate::dock_windows::MonitorDock;
 use crate::state::DockState;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-//! [`DockState`] — the cross-handler mutable state shared via `Rc<RefCell<>>`.
+//! `DockState` — the cross-handler mutable state shared via `Rc<RefCell<>>`.
 //!
 //! Owns the client list, pinned items, drag state, and launch-animation state.
 //! All cross-boundary mutations go through invariant-preserving methods (see

--- a/src/state.rs
+++ b/src/state.rs
@@ -109,6 +109,12 @@ impl DockState {
         config: Rc<DockConfig>,
         args_matches: clap::ArgMatches,
     ) -> Self {
+        // Seed scaled-icon size from the configured icon size; the
+        // first rebuild adjusts it via `scale_icon_size` based on the
+        // actual item count, but we want the initial value to reflect
+        // the user's `--icon-size` rather than duplicating the default
+        // from `config.rs` here as a magic literal.
+        let img_size_scaled = config.icon_size;
         Self {
             config,
             args_matches,
@@ -117,7 +123,7 @@ impl DockState {
             pinned: Vec::new(),
             app_dirs,
             compositor,
-            img_size_scaled: 48,
+            img_size_scaled,
             popover_open: false,
             locked: false,
             drag_pending: false,
@@ -332,7 +338,21 @@ impl DockState {
     /// Refreshes client list from the compositor.
     pub(crate) fn refresh_clients(&mut self) -> anyhow::Result<()> {
         self.clients = self.compositor.list_clients()?;
-        self.active_client = self.compositor.get_active_window().ok();
+        // `get_active_window` failing is distinct from "no active window".
+        // The previous `.ok()` shape collapsed both into None, so a
+        // genuine IPC failure (socket dropped, malformed payload) was
+        // indistinguishable from a workspace with no focused client.
+        // Log at debug so the trail is in journalctl when a user
+        // reports stale highlight, but don't propagate — the dock
+        // should keep running with its previous active-client snapshot
+        // rather than tearing down the rebuild path.
+        self.active_client = match self.compositor.get_active_window() {
+            Ok(client) => Some(client),
+            Err(e) => {
+                log::debug!("get_active_window failed: {e}");
+                None
+            }
+        };
         Ok(())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,17 @@
+//! [`DockState`] — the cross-handler mutable state shared via `Rc<RefCell<>>`.
+//!
+//! Owns the client list, pinned items, drag state, and launch-animation state.
+//! All cross-boundary mutations go through invariant-preserving methods (see
+//! `set_drag_pending`/`claim_drag`/`end_drag` and `start_launch`/`cancel_launch`)
+//! rather than direct field access, so the coupled-field invariants documented
+//! in the struct can be enforced by construction.
+//!
+//! **State borrowing:** see CLAUDE.md's "State borrowing conventions" section.
+//! The key rule: always `drop(s)` a `RefMut` before calling `rebuild()` to
+//! avoid a `BorrowMutError` panic. The reentrancy guard in `rebuild.rs` exists
+//! for the same reason — glycin's icon loading can pump the GTK main loop and
+//! re-enter a rebuild while one is already in flight.
+
 use crate::config::DockConfig;
 use gtk4::glib;
 use nwg_common::compositor::{Compositor, WmClient};

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -10,6 +10,13 @@ pub(crate) const DEFAULT_BG_RGB: (u8, u8, u8) = (54, 54, 79);
 /// Thickness of the Sway hotspot trigger window in pixels.
 pub(crate) const HOTSPOT_THICKNESS: i32 = 4;
 
+/// Near-zero alpha for the hotspot trigger window's CSS background.
+/// Just opaque enough that the compositor delivers input events to
+/// the surface (some compositors skip fully-transparent windows for
+/// hit-testing) but invisible to the user. Value is load-bearing —
+/// changing to 0.0 would break input delivery on those compositors.
+pub(crate) const HOTSPOT_INPUT_ALPHA: f64 = 0.01;
+
 /// Pixel margin beyond the dock bounds before a drag-off triggers unpin.
 pub(crate) const DRAG_OUTSIDE_MARGIN: f64 = 30.0;
 
@@ -55,13 +62,6 @@ pub(crate) const INDICATOR_DIVISOR: i32 = 8;
 /// paths can't drift. Will move alongside the alpha computation when
 /// CR-2026-05-03-17 consolidates the CSS-reload logic into `ui::css`.
 pub(crate) const OPACITY_PERCENT_MAX: u8 = 100;
-
-/// Near-zero alpha for the hotspot trigger window's CSS background.
-/// Just opaque enough that the compositor delivers input events to
-/// the surface (some compositors skip fully-transparent windows for
-/// hit-testing) but invisible to the user. Value is load-bearing —
-/// changing to 0.0 would break input delivery on those compositors.
-pub(crate) const HOTSPOT_INPUT_ALPHA: f64 = 0.01;
 
 /// Item count at which icon-size scaling kicks in. When the dock holds
 /// more than this many items, icons shrink to keep them all visible.

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -55,3 +55,16 @@ pub(crate) const INDICATOR_DIVISOR: i32 = 8;
 /// paths can't drift. Will move alongside the alpha computation when
 /// CR-2026-05-03-17 consolidates the CSS-reload logic into `ui::css`.
 pub(crate) const OPACITY_PERCENT_MAX: u8 = 100;
+
+/// Item count at which icon-size scaling kicks in. When the dock holds
+/// more than this many items, icons shrink to keep them all visible.
+/// Used by `ui::dock_box::scale_icon_size`.
+pub(crate) const SCALE_THRESHOLD_ITEMS: i32 = 6;
+
+/// Denominator step for each scaling increment beyond the threshold.
+/// One scaling step is applied for every `SCALE_STEP_ITEMS` items over
+/// the threshold. Note the integer-division plateau: items 7-8 still
+/// return full size because `(n - 6) / 3 == 0` for n ∈ {7, 8}; the
+/// first actual scaling step fires at n = 9 (overflow = 1).
+/// Used by `ui::dock_box::scale_icon_size`.
+pub(crate) const SCALE_STEP_ITEMS: i32 = 3;

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -56,6 +56,13 @@ pub(crate) const INDICATOR_DIVISOR: i32 = 8;
 /// CR-2026-05-03-17 consolidates the CSS-reload logic into `ui::css`.
 pub(crate) const OPACITY_PERCENT_MAX: u8 = 100;
 
+/// Near-zero alpha for the hotspot trigger window's CSS background.
+/// Just opaque enough that the compositor delivers input events to
+/// the surface (some compositors skip fully-transparent windows for
+/// hit-testing) but invisible to the user. Value is load-bearing —
+/// changing to 0.0 would break input delivery on those compositors.
+pub(crate) const HOTSPOT_INPUT_ALPHA: f64 = 0.01;
+
 /// Item count at which icon-size scaling kicks in. When the dock holds
 /// more than this many items, icons shrink to keep them all visible.
 /// Used by `ui::dock_box::scale_icon_size`.

--- a/src/ui/dock_box.rs
+++ b/src/ui/dock_box.rs
@@ -343,7 +343,12 @@ mod tests {
     use std::collections::HashMap;
 
     fn default_config() -> DockConfig {
-        DockConfig::parse_from(["test"])
+        // Pin `--icon-size 48` explicitly so the scale-test assertions
+        // (1→48, 6→48, 8→48, 9→41, 12→36, 100→7) stay about
+        // `scale_icon_size`'s formula. Without the override these
+        // tests would also be silently asserting the current default
+        // of `icon_size` and would break if that default ever moved.
+        DockConfig::parse_from(["test", "--icon-size", "48"])
     }
 
     // ─── scale_icon_size: boundary and plateau cases ───────────────────────────

--- a/src/ui/dock_box.rs
+++ b/src/ui/dock_box.rs
@@ -2,6 +2,7 @@ use crate::config::DockConfig;
 use crate::context::DockContext;
 use crate::state::DockState;
 use crate::ui::buttons;
+use crate::ui::constants::{SCALE_STEP_ITEMS, SCALE_THRESHOLD_ITEMS};
 use gtk4::prelude::*;
 use nwg_common::compositor::WmClient;
 use nwg_common::pinning;
@@ -83,11 +84,19 @@ fn is_child_window_grouped(task: &WmClient, all_items: &[String]) -> bool {
 }
 
 /// Scales icon size down when too many apps would overflow the dock.
+///
+/// Formula: `icon_size * SCALE_THRESHOLD_ITEMS / (SCALE_THRESHOLD_ITEMS + overflow)`,
+/// where `overflow = (item_count - SCALE_THRESHOLD_ITEMS) / SCALE_STEP_ITEMS`.
+///
+/// Integer-division plateau: items 7-8 still return full size because
+/// `(n - 6) / 3 == 0` for n ∈ {7, 8}. The first actual scaling step fires
+/// at n = 9 (overflow = 1, result = `icon_size * 6 / 7`). This is by design,
+/// not a bug — a single extra item shouldn't shrink every icon.
 fn scale_icon_size(item_count: usize, config: &DockConfig) -> i32 {
     let count = item_count.max(1);
-    if config.icon_size * 6 / (count as i32) < config.icon_size {
-        let overflow = (item_count as i32 - 6) / 3;
-        config.icon_size * 6 / (6 + overflow)
+    if config.icon_size * SCALE_THRESHOLD_ITEMS / (count as i32) < config.icon_size {
+        let overflow = (item_count as i32 - SCALE_THRESHOLD_ITEMS) / SCALE_STEP_ITEMS;
+        config.icon_size * SCALE_THRESHOLD_ITEMS / (SCALE_THRESHOLD_ITEMS + overflow)
     } else {
         config.icon_size
     }
@@ -324,4 +333,180 @@ fn apply_launching_class(item_box: &gtk4::Box, app_id: &str, ctx: &DockContext) 
 /// Finds the Button widget inside a dock item box (which may also contain an indicator).
 fn find_child_button(item_box: &gtk4::Box) -> Option<gtk4::Button> {
     crate::ui::widgets::children(item_box).find_map(|w| w.downcast::<gtk4::Button>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use nwg_common::compositor::WmClient;
+    use std::collections::HashMap;
+
+    fn default_config() -> DockConfig {
+        DockConfig::parse_from(["test"])
+    }
+
+    // ─── scale_icon_size: boundary and plateau cases ───────────────────────────
+
+    /// 1 item → full size (well below threshold).
+    #[test]
+    fn scale_icon_size_one_item_full() {
+        let config = default_config();
+        assert_eq!(scale_icon_size(1, &config), 48);
+    }
+
+    /// 6 items → full size (exactly at threshold, branch not taken).
+    #[test]
+    fn scale_icon_size_threshold_boundary_full() {
+        let config = default_config();
+        assert_eq!(scale_icon_size(6, &config), 48);
+    }
+
+    /// 8 items → plateau case: branch IS taken but overflow = 0, so full size
+    /// is still returned. Pinned so refactors don't accidentally change the
+    /// boundary — items 7-8 staying at full size is intentional, not a bug.
+    #[test]
+    fn scale_icon_size_plateau_eight_items_still_full() {
+        let config = default_config();
+        assert_eq!(
+            scale_icon_size(8, &config),
+            48,
+            "items 7-8 hit the branch but overflow=0 — must stay at full size"
+        );
+    }
+
+    /// 9 items → first actual scale step: overflow = 1, result = 48 * 6 / 7 = 41.
+    #[test]
+    fn scale_icon_size_nine_items_first_step() {
+        let config = default_config();
+        assert_eq!(scale_icon_size(9, &config), 41);
+    }
+
+    /// 12 items → second scale step: overflow = 2, result = 48 * 6 / 8 = 36.
+    #[test]
+    fn scale_icon_size_twelve_items_second_step() {
+        let config = default_config();
+        assert_eq!(scale_icon_size(12, &config), 36);
+    }
+
+    /// 100 items → asymptote sanity: result must be tiny but non-zero.
+    #[test]
+    fn scale_icon_size_hundred_items_asymptote() {
+        let config = default_config();
+        let result = scale_icon_size(100, &config);
+        assert_eq!(result, 7, "expected 48 * 6 / (6 + 31) = 7");
+        assert!(result > 0, "icon size must be > 0 even with many items");
+    }
+
+    /// Zero items treated as 1 (defensive floor) — should not panic or divide by zero.
+    #[test]
+    fn scale_icon_size_zero_items_clamped() {
+        let config = default_config();
+        assert_eq!(scale_icon_size(0, &config), 48);
+    }
+
+    // ─── is_class_represented: direct match, alt variant, wm-class map ─────────
+
+    #[test]
+    fn is_class_represented_direct_match_case_insensitive() {
+        let items = vec!["Firefox".to_string()];
+        assert!(is_class_represented("firefox", &items, &HashMap::new()));
+        assert!(is_class_represented("FIREFOX", &items, &HashMap::new()));
+    }
+
+    #[test]
+    fn is_class_represented_hyphen_space_variant() {
+        let items = vec!["github-desktop".to_string()];
+        // "github desktop" should match via hyphen-space variant
+        assert!(is_class_represented(
+            "github desktop",
+            &items,
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn is_class_represented_via_wm_class_map() {
+        let items = vec!["billz".to_string()];
+        let mut map = HashMap::new();
+        map.insert("com.billz.app".to_string(), "billz".to_string());
+        assert!(is_class_represented("com.billz.app", &items, &map));
+    }
+
+    #[test]
+    fn is_class_represented_not_found() {
+        let items = vec!["firefox".to_string()];
+        assert!(!is_class_represented("chromium", &items, &HashMap::new()));
+    }
+
+    // ─── is_child_window_grouped ──────────────────────────────────────────────
+
+    fn make_client(class: &str, initial_class: &str) -> WmClient {
+        WmClient::default()
+            .with_class(class)
+            .with_initial_class(initial_class)
+    }
+
+    #[test]
+    fn is_child_window_grouped_matches_initial_class() {
+        let task = make_client("Playwright", "Code");
+        let all_items = vec!["code".to_string()];
+        // initial_class "Code" is in all_items (case-insensitive) → grouped
+        assert!(is_child_window_grouped(&task, &all_items));
+    }
+
+    #[test]
+    fn is_child_window_grouped_no_initial_class() {
+        let task = make_client("firefox", "");
+        let all_items = vec!["firefox".to_string()];
+        assert!(!is_child_window_grouped(&task, &all_items));
+    }
+
+    #[test]
+    fn is_child_window_grouped_same_class_and_initial_class() {
+        // If class == initial_class the function must return false — the
+        // window is not a child and should not be grouped away.
+        let task = make_client("firefox", "firefox");
+        let all_items = vec!["firefox".to_string()];
+        assert!(!is_child_window_grouped(&task, &all_items));
+    }
+
+    // ─── should_skip_running ──────────────────────────────────────────────────
+
+    #[test]
+    fn should_skip_running_empty_class() {
+        let task = make_client("", "");
+        assert!(should_skip_running(&task, &[], &[], &[], &HashMap::new()));
+    }
+
+    #[test]
+    fn should_skip_running_ignored_class() {
+        let task = make_client("steam", "steam");
+        assert!(should_skip_running(
+            &task,
+            &[],
+            &["steam".to_string()],
+            &[],
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn should_skip_running_pinned() {
+        let task = make_client("firefox", "firefox");
+        assert!(should_skip_running(
+            &task,
+            &["firefox".to_string()],
+            &[],
+            &[],
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn should_skip_running_not_skipped_when_free() {
+        let task = make_client("firefox", "firefox");
+        // Not pinned, not ignored, not child — should NOT skip
+        assert!(!should_skip_running(&task, &[], &[], &[], &HashMap::new()));
+    }
 }

--- a/src/ui/hotspot/hotspot_windows.rs
+++ b/src/ui/hotspot/hotspot_windows.rs
@@ -2,7 +2,7 @@ use super::show_on_monitor_only_by_name;
 use crate::config::DockConfig;
 use crate::dock_windows::MonitorDock;
 use crate::state::DockState;
-use crate::ui::constants::HOTSPOT_THICKNESS;
+use crate::ui::constants::{HOTSPOT_INPUT_ALPHA, HOTSPOT_THICKNESS};
 use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
@@ -158,7 +158,9 @@ fn create_hotspot_window(
     static CSS_LOADED: std::sync::Once = std::sync::Once::new();
     CSS_LOADED.call_once(|| {
         let provider = gtk4::CssProvider::new();
-        provider.load_from_data(".dock-hotspot { background: rgba(0,0,0,0.01); }");
+        provider.load_from_data(&format!(
+            ".dock-hotspot {{ background: rgba(0,0,0,{HOTSPOT_INPUT_ALPHA}); }}"
+        ));
         if let Some(display) = gtk4::gdk::Display::default() {
             gtk4::style_context_add_provider_for_display(
                 &display,


### PR DESCRIPTION
## Summary

PR 6 — the **final bundle** of the post-0.4.0 code-refinement rollout (epic #70). Five fillers that close out the original 24 findings from \`docs/code-review/2026-05-03-comprehensive.md\`. After this lands, only the two late-additions discovered during reviews remain: **#73 / CR-25** (\`show_context_menu\` → \`DockContext\`) and **#77 / CR-26** (CSS watcher rebinding) — to be picked up before any version cut.

- **#54 / CR-09** — Rename \`ActivateParams\` → \`DockBootstrap\`. Doc-comment rewritten as a clean lifecycle distinction (startup-only fields vs. recurring rebuild path) instead of "acknowledging the smell" of the overlap with \`DockContext\`. Three callsites touched (struct definition, instantiation, \`activate_dock\` signature). Did not absorb \`DockContext\` as a sub-struct — that's the optional alternative per the spec, deferred.
- **#66 / CR-21** — \`scale_icon_size\` constants + plateau-pinning tests. Extracted \`SCALE_THRESHOLD_ITEMS\` and \`SCALE_STEP_ITEMS\` to \`ui/constants.rs\` with formula doc-comments explaining the integer-division plateau (items 7-8 still return full size; first scale step at 9). 18 new unit tests cover the boundary cases (1, 6, 8 plateau, 9 first-step, 12, 100 asymptote) for \`scale_icon_size\` plus the other pure helpers in \`dock_box.rs\` (\`is_class_represented\`, \`is_child_window_grouped\`, \`should_skip_running\`).
- **#67 / CR-22** — Extract \`HOTSPOT_INPUT_ALPHA: f64 = 0.01\` constant for the hotspot trigger window's near-zero alpha. Doc-comment explains the load-bearing nature (compositors that skip fully-transparent windows for hit-testing would lose input delivery if this went to 0.0).
- **#68 / CR-23** — Add \`//!\` module-level docs to nine top-level \`src/\` files (\`main.rs\`, \`state.rs\`, \`dock_windows.rs\`, \`events.rs\`, \`listeners.rs\`, \`monitor.rs\`, \`rebuild.rs\`, \`context.rs\`, \`config.rs\`). Each header explains what the module owns and references cross-cutting CLAUDE.md sections so the docs network together.
- **#69 / CR-24** — Fix the \`ui::widgets::app_icon_button()\` reference in CLAUDE.md. Replaced with a pointer to \`ui::buttons::pinned_button\` (and siblings) as the canonical pattern. The optional helper extraction stays a follow-up per the doc's fix-shape convention.

Source: [\`docs/code-review/2026-05-03-comprehensive.md\`](https://github.com/jasonherald/nwg-dock/blob/main/docs/code-review/2026-05-03-comprehensive.md). Each commit message references its CR-ID.

## Notable design decisions

- **CR-21 helper coverage.** The spec listed \`collect_all_items\` and \`build_pinned_items\`/\`build_running_items\` as candidates for unit testing, but those take \`&mut DockState\` or \`&DockContext\` and either mutate live state or build GTK widgets — not pure. Pivoted to the genuinely pure helpers (\`is_class_represented\`, \`is_child_window_grouped\`, \`should_skip_running\`) that match the spec's spirit. Spec reviewer verified and signed off.
- **CR-21 \`WmClient\` builder pattern.** \`WmClient\` is \`#[non_exhaustive]\` in nwg-common-0.4.0. Tests use the existing fluent setters (\`with_class()\` / \`with_initial_class()\`) rather than struct-literal construction.
- **CR-23 plain backticks, not rustdoc links.** Initial draft used \`[\`Symbol\`]\` rustdoc intra-doc links throughout the new module headers, but for a binary crate without \`--document-private-items\`, those silently degrade (rustdoc doesn't index private/\`pub(crate)\` items). The pre-PR-6 module-doc convention (visible in \`ui/drag.rs\`, \`ui/workspaces.rs\`, \`config_file/mod.rs\`) used plain backticks throughout — fixed in commit \`0e4ed5e\` to match.
- **CR-22 constant placement.** Initially landed after \`OPACITY_PERCENT_MAX\`; moved up next to \`HOTSPOT_THICKNESS\` post-review for thematic grouping with the other hotspot tunables.

## Verification

- \`cargo build --release\` ✅
- \`cargo test\` ✅ (169 unit + 4 integration; up from 151 unit because CR-21 added 18 new tests for \`scale_icon_size\` and the other pure helpers)
- \`cargo clippy --all-targets\` ✅ (zero warnings)
- \`cargo fmt --all -- --check\` ✅
- Spec compliance review: SPEC_COMPLIANT (all five CRs ✅, all three deviations evaluated as JUSTIFIED with concrete evidence)
- Code quality review: APPROVED with two nits — both addressed in commit \`0e4ed5e\` (rustdoc links → plain backticks; \`HOTSPOT_INPUT_ALPHA\` placement)
- Local \`make upgrade\` smoke-tested by the maintainer: cold start, hotspot input on Sway autohide, pinned launches (exercises the CR-21-tested pure helpers at runtime), \`scale_icon_size\` boundary at 9+ apps — all clean, no regressions

## Test plan

- [ ] CI green (fmt, clippy, test, deny, audit, codeql, CodeRabbit)
- [x] Reviewer eyeball on the new \`DockBootstrap\` doc-comment — does the lifecycle framing actually clarify the relationship with \`DockContext\`?
- [x] Reviewer eyeball on \`scale_icon_size\` test boundaries — particularly the \`8 items → still full size\` case which pins the integer-division plateau
- [x] Reviewer eyeball on the nine new \`//!\` headers — do they help a contributor understand what each module is for?

## What's left after this PR

After merge + close-out, the rollout is at 24/24 of the original review-doc findings. Two follow-ups remain in the epic before any version cut:
- **#73 / CR-25** — Refactor \`show_context_menu\` to consume \`DockContext\` (api-hygiene)
- **#77 / CR-26** — Rebind CSS watcher when \`css-file\` changes via hot-reload (architecture; cross-crate change with \`nwg-common\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI opacity now enforces 0–100 at parse time.
  * Configurable hotspot transparency and icon-scaling thresholds; initial icon size now honors configured value.

* **Bug Fixes**
  * Prevents invalid opacity values from being accepted.

* **Documentation**
  * Clarified button layout and added extensive module-level docs across startup, events, monitors, rebuilds, and listeners.

* **Tests**
  * Expanded unit tests for opacity parsing, icon-scaling, and related helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->