### PR TITLE
show_context_menu → &DockContext: CR-25

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -20,6 +20,8 @@ use std::rc::Rc;
 /// Shared context passed to all dock UI builders.
 ///
 /// Bundles the commonly-needed references so functions don't need 5+ parameters.
+/// All fields are `Rc`s, so cloning is cheap (reference-count bumps only).
+#[derive(Clone)]
 pub(crate) struct DockContext {
     pub(crate) config: Rc<DockConfig>,
     pub(crate) state: Rc<RefCell<DockState>>,

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -224,26 +224,13 @@ pub(crate) fn task_button(
     // Right-click → context menu
     let class = client.class.clone();
     let insts = instances.to_vec();
-    let config_ref = ctx.config.as_ref().clone();
-    let state_ref = Rc::clone(&ctx.state);
-    let comp = Rc::clone(&ctx.compositor);
-    let pinned_path = ctx.pinned_file.as_ref().clone();
-    let rebuild_ref = Rc::clone(&ctx.rebuild);
+    let ctx_right = ctx.clone();
     let right = gtk4::GestureClick::new();
     right.set_button(3);
     right.connect_released(move |gesture, _, _, _| {
         gesture.set_state(gtk4::EventSequenceState::Claimed);
         if let Some(widget) = gesture.widget() {
-            menus::show_context_menu(
-                &class,
-                &insts,
-                &config_ref,
-                &state_ref,
-                &comp,
-                &pinned_path,
-                &rebuild_ref,
-                &widget,
-            );
+            menus::show_context_menu(&class, &insts, &ctx_right, &widget);
         }
     });
     button.add_controller(right);

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -106,6 +106,10 @@ pub(crate) fn show_context_menu(
             }
         }));
 
+        // Workspaces are 1-indexed by Hyprland/Sway convention — there is no
+        // "workspace 0" on either compositor. The upper bound `num_ws` comes
+        // from `--num-ws` (default 5; see `config.rs`) and matches the
+        // workspace switcher widget's range in `ui::workspaces`.
         for ws in 1..=ctx.config.num_ws {
             actions_box.append(&action_button(&format!("-> WS {ws}"), &popover, {
                 let id = id.clone();

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -1,4 +1,4 @@
-use crate::config::DockConfig;
+use crate::context::DockContext;
 use crate::state::DockState;
 use gtk4::prelude::*;
 use nwg_common::compositor::{Compositor, WmClient};
@@ -58,18 +58,13 @@ pub(crate) fn show_client_menu(
 }
 
 /// Creates and shows a context menu for a task (right-click).
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn show_context_menu(
     class: &str,
     instances: &[WmClient],
-    config: &DockConfig,
-    state: &Rc<RefCell<DockState>>,
-    compositor: &Rc<dyn Compositor>,
-    pinned_file: &Path,
-    rebuild: &Rc<dyn Fn()>,
+    ctx: &DockContext,
     parent: &impl IsA<gtk4::Widget>,
 ) {
-    let popover = create_tracked_popover(parent, state);
+    let popover = create_tracked_popover(parent, &ctx.state);
 
     let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 2);
 
@@ -85,7 +80,7 @@ pub(crate) fn show_context_menu(
 
         actions_box.append(&action_button("Close", &popover, {
             let id = id.clone();
-            let comp = Rc::clone(compositor);
+            let comp = Rc::clone(&ctx.compositor);
             move || {
                 if let Err(e) = comp.close_window(&id) {
                     log::debug!("close_window failed for '{id}': {e}"); // Best-effort: window may have closed
@@ -94,7 +89,7 @@ pub(crate) fn show_context_menu(
         }));
         actions_box.append(&action_button("Toggle Floating", &popover, {
             let id = id.clone();
-            let comp = Rc::clone(compositor);
+            let comp = Rc::clone(&ctx.compositor);
             move || {
                 if let Err(e) = comp.toggle_floating(&id) {
                     log::debug!("toggle_floating failed for '{id}': {e}"); // Best-effort: window may have closed
@@ -103,7 +98,7 @@ pub(crate) fn show_context_menu(
         }));
         actions_box.append(&action_button("Fullscreen", &popover, {
             let id = id.clone();
-            let comp = Rc::clone(compositor);
+            let comp = Rc::clone(&ctx.compositor);
             move || {
                 if let Err(e) = comp.toggle_fullscreen(&id) {
                     log::debug!("toggle_fullscreen failed for '{id}': {e}"); // Best-effort: window may have closed
@@ -111,10 +106,10 @@ pub(crate) fn show_context_menu(
             }
         }));
 
-        for ws in 1..=config.num_ws {
+        for ws in 1..=ctx.config.num_ws {
             actions_box.append(&action_button(&format!("-> WS {ws}"), &popover, {
                 let id = id.clone();
-                let comp = Rc::clone(compositor);
+                let comp = Rc::clone(&ctx.compositor);
                 move || {
                     if let Err(e) = comp.move_to_workspace(&id, ws) {
                         log::debug!("move_to_workspace failed for '{id}' ws={ws}: {e}"); // Best-effort: window may have closed
@@ -131,7 +126,7 @@ pub(crate) fn show_context_menu(
     let btn = gtk4::Button::with_label("New window");
     btn.add_css_class("flat");
     let class_str = class.to_string();
-    let app_dirs = state.borrow().app_dirs.clone();
+    let app_dirs = ctx.state.borrow().app_dirs.clone();
     let p = popover.clone();
     btn.connect_clicked(move |_| {
         nwg_common::launch::launch(&class_str, &app_dirs);
@@ -144,7 +139,7 @@ pub(crate) fn show_context_menu(
     btn.add_css_class("flat");
     let insts: Vec<String> = instances.iter().map(|i| i.id.clone()).collect();
     let p = popover.clone();
-    let comp = Rc::clone(compositor);
+    let comp = Rc::clone(&ctx.compositor);
     btn.connect_clicked(move |_| {
         for id in &insts {
             if let Err(e) = comp.close_window(id) {
@@ -156,7 +151,7 @@ pub(crate) fn show_context_menu(
     vbox.append(&btn);
 
     // Pin/Unpin
-    let is_pinned = pinning::is_pinned(&state.borrow().pinned, class);
+    let is_pinned = pinning::is_pinned(&ctx.state.borrow().pinned, class);
     let btn = if is_pinned {
         gtk4::Button::with_label("Unpin")
     } else {
@@ -164,9 +159,9 @@ pub(crate) fn show_context_menu(
     };
     btn.add_css_class("flat");
     let class_str = class.to_string();
-    let state_ref = Rc::clone(state);
-    let pinned_path = pinned_file.to_path_buf();
-    let rebuild_ref = Rc::clone(rebuild);
+    let state_ref = Rc::clone(&ctx.state);
+    let pinned_path = ctx.pinned_file.as_ref().to_path_buf();
+    let rebuild_ref = Rc::clone(&ctx.rebuild);
     let p = popover.clone();
     btn.connect_clicked(move |_| {
         let mut s = state_ref.borrow_mut();


### PR DESCRIPTION
## Summary

PR 7 — first of two **late-additions** under epic #70 (the original 24 review-doc findings landed across PRs 1-6). Single mechanical refactor.

- **#73 / CR-25** — Refactor \`show_context_menu\` to consume \`&DockContext\` instead of five separate refs (\`config\`, \`state\`, \`compositor\`, \`pinned_file\`, \`rebuild\`). The five-ref bundle was exactly the anti-pattern \`DockContext\` exists to absorb — CLAUDE.md's \"DockContext for clean function signatures; never pass 7+ individual refs\" applies even at five.

The function's external behavior is unchanged: same menu items (Close, Toggle Floating, Fullscreen, Move to workspace N, New window, Close all, Pin/Unpin), same compositor actions, same pin-file writes, same rebuild firing. This PR is a signature rewrite, not a feature change.

Source: GitHub issue [#73](https://github.com/jasonherald/nwg-dock/issues/73), filed during PR #72's review and tracked under epic [#70](https://github.com/jasonherald/nwg-dock/issues/70)'s *Late additions* section.

## Notable design decisions

- **\`#[derive(Clone)]\` added to \`DockContext\`.** GTK's \`connect_released\` closure requires \`'static\` captured values, so the call site moves an owned \`DockContext\` in. Rather than six individual \`Rc::clone\` calls (the exact anti-pattern CR-25 targets, just hidden inside the closure), the implementer derives \`Clone\` on the type. Every \`DockContext\` field is an \`Rc<T>\`, so cloning is six refcount bumps with no heap allocation. The derive is \`pub(crate)\` and a doc comment on the struct explains the cheap-clone invariant. Both reviewers verified this is the minimum-correct shape.
- **Single call site.** \`grep -rn 'show_context_menu' src/\` returns the definition and exactly one production caller (\`src/ui/buttons.rs:233\`). No test references existed. Refactor was contained.
- **Did NOT absorb \`DockContext\` into \`DockBootstrap\` as a sub-struct.** That was the *Alternative considered* per the review-doc fix-shape convention, deferred indefinitely.

## Verification

- \`cargo build --release\` ✅
- \`cargo test\` ✅ (172 unit + 4 integration; same as PR 6's tip — this PR adds no new tests, signature change only)
- \`cargo clippy --all-targets\` ✅ (zero warnings; the \`#[allow(clippy::too_many_arguments)]\` attribute on the old signature is also gone since it no longer fires)
- \`cargo fmt --all -- --check\` ✅
- Spec compliance review: SPEC_COMPLIANT (every check ✅, deviation justified)
- Code quality review: APPROVED (single nit — surviving \`use\` imports in \`menus.rs\` for \`Path\` and \`RefCell\` are still legitimately used by sibling functions, no action required)
- Local \`make upgrade\` smoke-tested by the maintainer: right-click menus on running apps and pinned apps (Close, Toggle Floating, Fullscreen, Move-to-workspace, Pin/Unpin), drawer pin-file sync, dock background settings menu — all clean, no regressions.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, audit, codeql, CodeRabbit)
- [x] Reviewer eyeball on the \`#[derive(Clone)]\` shape — every \`DockContext\` field is \`Rc<T>\`, so cloning is cheap, but worth confirming
- [x] Reviewer eyeball on the call site at \`src/ui/buttons.rs:227\` — the \`let ctx_right = ctx.clone()\` shape that replaces the prior six-Rc-clone block

## What's left after this PR

After merge + close-out, the rollout has **one** finding remaining: **#77 / CR-26** (CSS watcher rebinding) — a cross-crate change requiring a new API in \`nwg-common::config::css\`. That's PR 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated several internal parameters into a unified context, simplifying APIs and internal wiring.

* **Chores / Improvements**
  * Optimized context cloning and streamlined right-click menu handling for slightly lower overhead and more robust menu behavior; no user-facing UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->