### PR TITLE
feat(css): rebind CSS watcher on css-file hot-reload (CR-26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,9 +1204,9 @@ checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "nwg-common"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406ced31ecc8842d92eb2c828dc9ad69ba143ebbdbeae702041ec0da02026977"
+checksum = "37643d5e67cc883e6f973651366b758d574bfdfac030c4c233606bf15415f294"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "nwg-dock"
 path = "src/main.rs"
 
 [dependencies]
-# Shared library (library + binaries all on the 0.4.x line)
-nwg-common = "0.4"
+# Shared library (library + binaries all on the 0.5.x line)
+nwg-common = "0.5"
 
 # GTK4 + Wayland layer shell
 gtk4 = "0.10"

--- a/src/config_file/hot_reload.rs
+++ b/src/config_file/hot_reload.rs
@@ -155,14 +155,14 @@ pub(crate) fn apply_config_change(
         }
     );
 
-    apply_hot_reloadable_changes(&old, &new, per_monitor, state);
+    let css_file_applied = apply_hot_reloadable_changes(&old, &new, per_monitor, state);
 
     // Build the config that becomes state.config after this reload.
     // For Applicable: it's `new` verbatim. For RestartRequired: it's
     // `new` with the restart-required fields overwritten by `old`'s
     // values, so subsequent reloads still flag those as needing
     // restart until the process actually restarts.
-    let next_config = match &result {
+    let mut next_config = match &result {
         DiffResult::RestartRequired { restart_fields, .. } => {
             let mut partial = new;
             preserve_restart_fields(&old, &mut partial, restart_fields);
@@ -170,6 +170,16 @@ pub(crate) fn apply_config_change(
         }
         _ => new,
     };
+
+    // If the css-file rebind failed, the watcher is still pointing at the
+    // OLD file. Keep `state.config.css_file` aligned with what the watcher
+    // actually watches — otherwise the next save with the same broken
+    // path would see `old.css_file == new.css_file` and silently skip the
+    // rebind branch, re-introducing the watcher-stale failure mode this
+    // path exists to surface. (CodeRabbit catch on PR 80.)
+    if !css_file_applied {
+        next_config.css_file = old.css_file.clone();
+    }
 
     state.borrow_mut().config = Rc::new(next_config);
 
@@ -188,12 +198,19 @@ pub(crate) fn apply_config_change(
 /// field on both `old` and `new` and only fires the update when the
 /// value actually changed. Safe to call on every reload; idempotent
 /// when nothing in this subset changed.
+///
+/// Returns `true` when the `css_file` change applied (or no change was
+/// requested), `false` when the rebind failed and the watcher still
+/// points at `old.css_file`. The caller uses this to keep
+/// `state.config.css_file` aligned with the watcher — committing
+/// `new.css_file` after a failed rebind would silently re-introduce
+/// the watcher-stale bug on the next save with the same broken path.
 fn apply_hot_reloadable_changes(
     old: &DockConfig,
     new: &DockConfig,
     per_monitor: &Rc<RefCell<Vec<crate::dock_windows::MonitorDock>>>,
     state: &Rc<RefCell<crate::state::DockState>>,
-) {
+) -> bool {
     use gtk4_layer_shell::{Edge, LayerShell};
 
     // Margins: per-dock set_margin.
@@ -231,7 +248,10 @@ fn apply_hot_reloadable_changes(
     // CSS file path: atomically rebind the inotify watcher to the new
     // path so subsequent edits to the new file continue to hot-reload.
     // On error the old watcher is preserved and we surface a desktop
-    // notification so the user knows the path swap failed.
+    // notification so the user knows the path swap failed. The bool we
+    // return tells the caller whether to commit `new.css_file` into
+    // `state.config` (true) or preserve `old.css_file` so the next save
+    // can retry (false).
     if old.css_file != new.css_file {
         use super::notify::notify_user;
         let config_dir = nwg_common::config::paths::config_dir("nwg-dock-hyprland");
@@ -258,10 +278,27 @@ fn apply_hot_reloadable_changes(
                                 e
                             ),
                         );
+                        return false;
                     }
                 }
             } else {
-                log::warn!("No CssWatchHandle available; cannot rebind CSS file");
+                // Per the invariant on DockState.css_watch, this branch is
+                // only reachable on an init-order regression. Notify the
+                // user anyway so a future regression is loud at runtime
+                // instead of being buried in a journalctl line.
+                log::warn!(
+                    "No CssWatchHandle available; cannot rebind CSS file to {}",
+                    new_css_path.display()
+                );
+                drop(s);
+                notify_user(
+                    "nwg-dock: CSS reload failed",
+                    &format!(
+                        "Internal error: CSS watcher handle missing while attempting to rebind to '{}'; reload skipped",
+                        new_css_path.display()
+                    ),
+                );
+                return false;
             }
         } else {
             log::warn!(
@@ -275,8 +312,12 @@ fn apply_hot_reloadable_changes(
                     new_css_path.display()
                 ),
             );
+            return false;
         }
     }
+
+    // No css_file change requested, or the rebind succeeded.
+    true
 }
 
 /// Overwrites the restart-required fields on `target` with the

--- a/src/config_file/hot_reload.rs
+++ b/src/config_file/hot_reload.rs
@@ -1,4 +1,6 @@
 use crate::config::DockConfig;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 /// Fields that cannot be hot-reloaded — see spec
 /// `docs/superpowers/specs/2026-04-28-config-file-design.md` for the
@@ -131,9 +133,9 @@ fn diff_config(old: &DockConfig, new: &DockConfig) -> DiffResult {
 ///   their pre-edit values, so subsequent reloads still flag them).
 pub(crate) fn apply_config_change(
     new: DockConfig,
-    state: &std::rc::Rc<std::cell::RefCell<crate::state::DockState>>,
-    per_monitor: &std::rc::Rc<std::cell::RefCell<Vec<crate::dock_windows::MonitorDock>>>,
-    rebuild: &std::rc::Rc<dyn Fn()>,
+    state: &Rc<RefCell<crate::state::DockState>>,
+    per_monitor: &Rc<RefCell<Vec<crate::dock_windows::MonitorDock>>>,
+    rebuild: &Rc<dyn Fn()>,
 ) -> DiffResult {
     let old = state.borrow().config.clone();
     let result = diff_config(&old, &new);
@@ -169,7 +171,7 @@ pub(crate) fn apply_config_change(
         _ => new,
     };
 
-    state.borrow_mut().config = std::rc::Rc::new(next_config);
+    state.borrow_mut().config = Rc::new(next_config);
 
     // Single rebuild call covers icon-size, alignment, launcher-cmd,
     // launcher-pos, nolauncher, ico, ignore-classes, ignore-workspaces,
@@ -189,8 +191,8 @@ pub(crate) fn apply_config_change(
 fn apply_hot_reloadable_changes(
     old: &DockConfig,
     new: &DockConfig,
-    per_monitor: &std::rc::Rc<std::cell::RefCell<Vec<crate::dock_windows::MonitorDock>>>,
-    state: &std::rc::Rc<std::cell::RefCell<crate::state::DockState>>,
+    per_monitor: &Rc<RefCell<Vec<crate::dock_windows::MonitorDock>>>,
+    state: &Rc<RefCell<crate::state::DockState>>,
 ) {
     use gtk4_layer_shell::{Edge, LayerShell};
 
@@ -265,6 +267,13 @@ fn apply_hot_reloadable_changes(
             log::warn!(
                 "CSS file '{}' does not exist; skipping reload",
                 new_css_path.display()
+            );
+            notify_user(
+                "nwg-dock: CSS reload failed",
+                &format!(
+                    "Could not load new CSS file '{}': file does not exist; reload skipped",
+                    new_css_path.display()
+                ),
             );
         }
     }

--- a/src/config_file/hot_reload.rs
+++ b/src/config_file/hot_reload.rs
@@ -153,7 +153,7 @@ pub(crate) fn apply_config_change(
         }
     );
 
-    apply_hot_reloadable_changes(&old, &new, per_monitor);
+    apply_hot_reloadable_changes(&old, &new, per_monitor, state);
 
     // Build the config that becomes state.config after this reload.
     // For Applicable: it's `new` verbatim. For RestartRequired: it's
@@ -190,6 +190,7 @@ fn apply_hot_reloadable_changes(
     old: &DockConfig,
     new: &DockConfig,
     per_monitor: &std::rc::Rc<std::cell::RefCell<Vec<crate::dock_windows::MonitorDock>>>,
+    state: &std::rc::Rc<std::cell::RefCell<crate::state::DockState>>,
 ) {
     use gtk4_layer_shell::{Edge, LayerShell};
 
@@ -225,16 +226,46 @@ fn apply_hot_reloadable_changes(
         log::set_max_level(level);
     }
 
-    // CSS file path: re-load from the new path. The existing CSS watcher
-    // is bound to the original path; restarting the watcher on a new
-    // path is out of scope for this PR (changing css-file mid-session
-    // is rare). reload_css_file delegates to load_css and discards the
-    // provider per the fire-and-forget pattern (CR-12).
+    // CSS file path: atomically rebind the inotify watcher to the new
+    // path so subsequent edits to the new file continue to hot-reload.
+    // On error the old watcher is preserved and we surface a desktop
+    // notification so the user knows the path swap failed.
     if old.css_file != new.css_file {
+        use super::notify::notify_user;
         let config_dir = nwg_common::config::paths::config_dir("nwg-dock-hyprland");
         let new_css_path = config_dir.join(&new.css_file);
         if new_css_path.exists() {
-            crate::ui::css::reload_css_file(&new_css_path);
+            let mut s = state.borrow_mut();
+            if let Some(handle) = s.css_watch.as_mut() {
+                match crate::ui::css::reload_css_file(handle, &new_css_path) {
+                    Ok(()) => {
+                        log::info!("CSS file rebound to {}", new_css_path.display());
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to rebind CSS to {}: {}", new_css_path.display(), e);
+                        // Release the borrow before issuing the notification —
+                        // notify_user does not touch state, but dropping here
+                        // keeps the CLAUDE.md "drop RefMut before code that
+                        // itself borrows state" rule visible at the call site.
+                        drop(s);
+                        notify_user(
+                            "nwg-dock: CSS reload failed",
+                            &format!(
+                                "Could not load new CSS file '{}': {}",
+                                new_css_path.display(),
+                                e
+                            ),
+                        );
+                    }
+                }
+            } else {
+                log::warn!("No CssWatchHandle available; cannot rebind CSS file");
+            }
+        } else {
+            log::warn!(
+                "CSS file '{}' does not exist; skipping reload",
+                new_css_path.display()
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ struct DockBootstrap {
 
 /// Sets up the dock UI: state, monitors, windows, rebuild function, and listeners.
 fn activate_dock(app: &gtk4::Application, params: &DockBootstrap) {
-    ui::css::load_dock_css(&params.css_path, params.config.opacity);
+    let css_handle = ui::css::load_dock_css(&params.css_path, params.config.opacity);
     let _hold = app.hold();
 
     let state = Rc::new(RefCell::new(DockState::new(
@@ -189,6 +189,7 @@ fn activate_dock(app: &gtk4::Application, params: &DockBootstrap) {
         Rc::clone(&params.config),
         (*params.matches).clone(),
     )));
+    state.borrow_mut().css_watch = Some(css_handle);
     state.borrow_mut().pinned = pinning::load_pinned(&params.pinned_file);
     state.borrow_mut().locked = ui::dock_menu::load_lock_state();
     state.borrow_mut().wm_class_to_desktop_id = build_wm_class_map(&params.app_dirs);

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@
 use crate::config::DockConfig;
 use gtk4::glib;
 use nwg_common::compositor::{Compositor, WmClient};
+use nwg_common::config::css::CssWatchHandle;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -40,6 +41,12 @@ pub(crate) struct DockState {
 
     /// Compositor backend for IPC calls.
     pub(crate) compositor: Rc<dyn Compositor>,
+
+    /// Handle for the CSS file watcher. `None` at construction; set by
+    /// `activate_dock` after `load_dock_css` returns the handle.
+    /// Used by the hot-reload path to atomically rebind the watcher
+    /// when the user changes `[appearance] css-file` at runtime.
+    pub(crate) css_watch: Option<CssWatchHandle>,
 
     /// Scaled icon size (adjusted when many apps are open).
     pub(crate) img_size_scaled: i32,
@@ -123,6 +130,7 @@ impl DockState {
             pinned: Vec::new(),
             app_dirs,
             compositor,
+            css_watch: None,
             img_size_scaled,
             popover_open: false,
             locked: false,

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,10 +42,19 @@ pub(crate) struct DockState {
     /// Compositor backend for IPC calls.
     pub(crate) compositor: Rc<dyn Compositor>,
 
-    /// Handle for the CSS file watcher. `None` at construction; set by
-    /// `activate_dock` after `load_dock_css` returns the handle.
-    /// Used by the hot-reload path to atomically rebind the watcher
-    /// when the user changes `[appearance] css-file` at runtime.
+    /// Handle for the CSS file watcher. Used by the hot-reload path to
+    /// atomically rebind the watcher when the user changes `[appearance]
+    /// css-file` at runtime.
+    ///
+    /// **Invariant:** `None` only during construction. `activate_dock`
+    /// sets this to `Some(_)` immediately after `load_dock_css` returns
+    /// the handle, *before* any user-reachable callbacks are wired up.
+    /// By the time hot-reload (or any other handler) can fire, this is
+    /// always `Some`. The `Option` shape exists only because the
+    /// handle's GTK provider isn't available at `DockState::new` time;
+    /// callers that observe `None` here are evidence of an init-order
+    /// regression and should be loud about it (warn + skip), not
+    /// silent.
     pub(crate) css_watch: Option<CssWatchHandle>,
 
     /// Scaled icon size (adjusted when many apps are open).

--- a/src/ui/css.rs
+++ b/src/ui/css.rs
@@ -1,5 +1,6 @@
 use super::constants::{DEFAULT_BG_RGB, OPACITY_PERCENT_MAX};
 use nwg_common::config::css;
+use nwg_common::config::css::CssWatchHandle;
 use std::path::Path;
 
 /// Default opacity used in the embedded GTK4 compat CSS before the
@@ -98,19 +99,27 @@ pub(crate) fn reload_opacity(opacity: u8) {
     css::load_css_override(&opacity_css);
 }
 
-/// Re-applies a user CSS file at runtime. The returned
-/// CssProvider is discarded — the existing CSS watcher (set up
-/// in `load_dock_css`) still owns the original provider, and
-/// `load_css` logs internally on failure.
-pub(crate) fn reload_css_file(path: &Path) {
-    css::load_css(path);
+/// Rebinds the CSS watcher to a new file path and loads the new stylesheet.
+///
+/// Delegates to [`CssWatchHandle::rebind`]: on `Err` the OLD watcher is
+/// preserved and hot-reload continues on the original file.
+pub(crate) fn reload_css_file(
+    handle: &mut CssWatchHandle,
+    new_path: &Path,
+) -> Result<(), css::CssRebindError> {
+    handle.rebind(new_path)
 }
 
 /// Loads the dock's CSS file and applies GTK4 compatibility overrides.
-/// Starts a file watcher for hot-reload of the user CSS.
-pub(crate) fn load_dock_css(css_path: &Path, opacity: u8) {
+/// Starts a rebindable file watcher for hot-reload of the user CSS.
+///
+/// Returns a [`CssWatchHandle`] that the caller must store for the process
+/// lifetime. The handle can be passed to [`reload_css_file`] when the user
+/// changes `[appearance] css-file` at runtime to atomically move the watcher
+/// to the new path.
+pub(crate) fn load_dock_css(css_path: &Path, opacity: u8) -> CssWatchHandle {
     let user_provider = css::load_css(css_path);
-    css::watch_css(css_path, &user_provider);
+    let watch_handle = css::watch_css_rebindable(css_path, &user_provider);
     // GTK4 button overrides as embedded defaults — user CSS can override via hot-reload
     css::load_css_from_data(&gtk4_compat_css());
 
@@ -141,4 +150,6 @@ pub(crate) fn load_dock_css(css_path: &Path, opacity: u8) {
         .dock-launching-vertical {{ animation: dock-bounce-vertical {LAUNCH_BOUNCE_DURATION_MS}ms linear infinite; }}",
     );
     css::load_css_from_data(&bounce_css);
+
+    watch_handle
 }


### PR DESCRIPTION
## Summary

- Stops the silent watcher-stale failure mode when `[appearance] css-file` is changed at runtime: rebinds the inotify watcher to the new path atomically (old watcher preserved on failure) instead of leaving subsequent edits to the new file un-watched.
- New cross-crate API in `nwg-common 0.5.0`: `watch_css_rebindable(path, provider) -> CssWatchHandle` plus `CssWatchHandle::rebind(new_path)` returning a typed `CssRebindError` (`Io` / `WatcherSetup`). Atomicity contract: new watcher is set up first; old is torn down only after both setup steps succeed.
- nwg-dock now stashes the `CssWatchHandle` on `DockState` and the config-file hot-reload path calls `reload_css_file(handle, &new_path)` when the user changes `css-file`.
- Failure surfaces both ways the user asked for: `log::warn!` to journalctl AND a desktop notification via `notify_user` so the failure is visible without tailing logs.
- Closes the watcher-rebind half of #77 (CR-2026-05-03-26).

## Cross-crate coordination

- nwg-common 0.5.0 was published to crates.io ahead of this PR (PR #7 in nwg-common, then `v0.5.0` tag → `cargo publish`). nwg-dock's `Cargo.toml` bumps the dep to `nwg-common = \"0.5\"` here.
- Same Phase A / Phase B pattern as the workspace-switcher rollout — the library API exists on the crates.io side before any consumer depends on it.

## Implementation notes

- `WatchState` now holds `Option<RecommendedWatcher>` (dormant when `None`); the previous code had a `make_null_watcher` panic path on resource exhaustion that's been eliminated. (Heavy-lift refactor done in-place per user direction; no deferments.)
- `compute_canonical_pair` returns `Result<_, std::io::Error>` so `canonicalize` errors surface verbatim instead of being collapsed into `None`.
- `build_watch_state` returns `Result<WatchState, BuildWatchError>` so `rebind` can surface real notify errors instead of generic strings.
- `CssWatchHandle` carries a manual `Debug` impl (path + strong_refs) since `gtk4::CssProvider` and `notify::RecommendedWatcher` aren't `Debug`-printable.
- The rebindable timer uses `Arc<Mutex<RebindableState>>` + `Weak` so it self-cancels cleanly when the handle is dropped — no `SourceId` plumbing required.
- State-borrow discipline: the rebind branch in `apply_hot_reloadable_changes` `drop(s)`s the `RefMut` before `notify_user` per CLAUDE.md's \"State borrowing conventions\" — `notify_user` doesn't touch state today, but the explicit drop keeps the rule visible at the call site.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` zero warnings
- [x] `cargo test` — 172 passed (nwg-dock); upstream nwg-common: 219 passed + 2 ignored (GTK-required)
- [x] `make upgrade` smoke test on a live dock — no regressions, no warnings in journalctl, hot-reload of margins/opacity/debug still works alongside the new css-file rebind path
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS hot-reload now shows desktop notifications when applying updated CSS fails.

* **Improvements**
  * Runtime CSS switching is more robust: the app retains and rebinds the CSS watcher atomically to avoid mismatches.
  * Better detection and user-facing reporting for CSS-related configuration and reload errors.

* **Chores**
  * Bumped shared library dependency to a newer compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->