### PR TITLE
Release nwg-dock v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-04
+
+### Added
+
+- `[appearance] css-file` is now hot-reloadable at runtime. Changing
+  the path in the config file and saving rebinds the inotify watcher
+  to the new file atomically, so subsequent edits to the new file
+  continue to live-reload without a dock restart. Previously the
+  watcher silently went stale after a path swap. Failure paths
+  (missing file, rebind error, or — if a regression ever broke the
+  init order — a missing watcher handle) now surface a desktop
+  notification in addition to the warn-level log so the failure is
+  visible without tailing journalctl. On rebind failure
+  `state.config.css_file` is kept aligned with the still-active old
+  watcher so a subsequent save with the same path actually retries.
+  (#77)
+
+### Changed
+
+- Bumped `nwg-common` dep to `0.5.0` for `watch_css_rebindable` /
+  `CssWatchHandle::rebind` / `CssRebindError`.
+- Internal: post-0.4.0 code-review rollout — 24 findings (CR-01
+  through CR-24) plus 2 late additions (CR-25 `show_context_menu` →
+  `&DockContext`, CR-26 css-file hot-reload above) covering
+  visibility tightening (`pub` → `pub(crate)` sweep), idiom
+  modernization (`From` over `as`, `f64::hypot`, inline format args,
+  let-else ladders), state-borrow invariant methods on `DockState`
+  (drag and launch-animation lifecycles), file decomposition
+  (`config_file/`, `events/`), constant extraction (`HOTSPOT_INPUT_ALPHA`,
+  `OPACITY_PERCENT_MAX`, `scale_icon_size` plateau constants), module
+  rustdoc headers, and explicit error logging in place of silent
+  `let _ = ...` discards. No external behavioural changes from these
+  beyond the css-file hot-reload above. See the rollout epic (#70)
+  and `docs/code-review/2026-05-03-comprehensive.md` for the full
+  audit trail.
+
 ## [0.4.0] — 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-dock"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-dock"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 
 sonar.projectKey=nwg-dock
 sonar.projectName=nwg-dock
-sonar.projectVersion=0.4.0
+sonar.projectVersion=0.5.0
 
 # Source code location — standalone repo has src/ at root (not crates/*/src/)
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Cuts the v0.5.0 release. Cargo.toml, Cargo.lock, and `sonar-project.properties` bumped from 0.4.0 → 0.5.0.
- CHANGELOG.md entry covers the post-0.4.0 review rollout: 24 findings (CR-01..CR-24) plus 2 late additions (CR-25, CR-26) shipped across PRs #71, #72, #74, #75, #76, #78, #79, #80.
- Headline user-facing change: `[appearance] css-file` is now hot-reloadable — see #77 / PR #80.

## Post-merge steps

After this merges I'll:

1. Tag `v0.5.0` against the merge commit and push
2. `cargo publish` to crates.io
3. Close epic #70 with a summary comment linking to the release tag

## Test plan

- [x] `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` — all clean
- [x] Metadata-only change (no source code touched) — exempt from smoke-test rule per project convention
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.5.0

* **New Features**
  * Enhanced CSS file hot-reload with atomic rebinding—automatically reattaches when CSS files change and surfaces errors via desktop notifications and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->