### PR TITLE
chore(deps): bump nwg-common 0.5 -> 0.5.1 for pixbuf-cache fix (#83)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,9 +1204,9 @@ checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "nwg-common"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37643d5e67cc883e6f973651366b758d574bfdfac030c4c233606bf15415f294"
+checksum = "030095b1dd25894f81b4c863e09eb039b5844c67bb34bba7212afc128a3a764b"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Shared library (library + binaries all on the 0.5.x line)
-nwg-common = "0.5"
+nwg-common = "0.5.1"
 
 # GTK4 + Wayland layer shell
 gtk4 = "0.10"


### PR DESCRIPTION
## Summary

- Bumps `nwg-common` from `"0.5"` to `"0.5.1"` to consume the icon-pixbuf-cache fix from [`nwg-common#8`](https://github.com/jasonherald/nwg-common/pull/8).
- Refs: #83 (long-uptime memory growth — 15.9 GiB peak observed over 2.5 days).
- No code changes in `nwg-dock` itself; the fix lives entirely in nwg-common's `desktop::icons` module.

## Why

heaptrack tracing in #83 pinned the leak to `gdk_pixbuf::Pixbuf::from_file_at_size` → `gly_loader_new` (glycin) called from `nwg_common::desktop::icons::create_pixbuf` on every dock rebuild. Glycin leaks a few KiB of decoder state per call. Caching by `(icon, size)` / `(path, w, h)` in nwg-common 0.5.1 means we only invoke the glycin path once per unique input.

## Validation

Two heaptrack runs against an identical 90-second focus-churn driver, before vs after the 0.5.1 swap:

| Metric | Before (0.5.0) | After (0.5.1) | Change |
|---|---|---|---|
| Total allocation calls | 10,609,623 | 2,853,474 | **-73%** |
| **Glycin internal allocation calls** | **3,547,015** | **7,170** | **-99.8%** |
| Allocator throughput | 68.7K calls/s | 25K calls/s | -64% |

The residual 7,170 glycin calls are the warm-up decodes for unique `(icon, size)` cache fills (~50 entries for a typical dock) — once warm, glycin shouldn't fire at all on rebuilds. The prior 65 KB/s churn-driven leak rate plateaus at the unique-input bound, eliminating the multi-GiB drift that compounded over days.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build` clean (pulls nwg-common 0.5.1 from crates.io)
- [x] `cargo clippy --all-targets` zero warnings
- [x] `cargo test` — 172 unit tests + 4 integration tests pass
- [x] `make upgrade` smoke test on a live dock — no regressions confirmed
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->