### PR TITLE
Release nwg-dock v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-05-05
+
+### Fixed
+
+- Long-uptime memory growth: dock no longer accumulates GiB of leaked
+  pixbuf decoder state on long-running sessions. The leak was traced
+  to glycin's per-decode internal allocations (modern
+  `gdk_pixbuf_new_from_file_at_scale` delegates to glycin), invoked
+  from the dock's icon-load path on every rebuild. heaptrack confirmed
+  ~3.5 M glycin allocator calls during a 90-second focus-churn run,
+  extrapolating to the 15.9 GiB peak RSS observed over 2.5 days
+  uptime in #83. Bumping `nwg-common` to `0.5.1` picks up a process-
+  lifetime pixbuf cache keyed by `(icon, size)` / `(path, w, h)`, so
+  glycin runs once per unique input rather than per rebuild — a 99.8%
+  reduction in glycin allocator calls under the same churn driver.
+  No code changes in `nwg-dock` itself; the fix lives entirely in
+  `nwg-common::desktop::icons`. (#83)
+
+### Changed
+
+- Bumped `nwg-common` dep to `0.5.1`.
+
 ## [0.5.0] — 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-dock"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-dock"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 
 sonar.projectKey=nwg-dock
 sonar.projectName=nwg-dock
-sonar.projectVersion=0.5.0
+sonar.projectVersion=0.5.1
 
 # Source code location — standalone repo has src/ at root (not crates/*/src/)
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Cuts the v0.5.1 release. \`Cargo.toml\`, \`Cargo.lock\`, and \`sonar-project.properties\` bumped from 0.5.0 → 0.5.1.
- CHANGELOG entry points at the long-uptime memory growth fix consumed via nwg-common 0.5.1 (#85).
- Headline user-facing change: dock no longer accumulates GiB of leaked pixbuf decoder state over multi-day sessions (#83).

## Post-merge steps

After this merges I'll:

1. Tag \`v0.5.1\` against the merge commit
2. \`cargo publish\` to crates.io

## Test plan

- [x] \`cargo build\`, \`cargo fmt --check\`, \`cargo clippy --all-targets\`, \`cargo test\` — all clean (172 unit tests + 4 integration tests pass)
- [x] Metadata-only change (no source code touched) — exempt from smoke-test rule per project convention; binary behaviour was already validated under #85's \`make upgrade\`
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.5.1 Release

* **Bug Fixes**
  * Resolved memory growth issues in long-running applications caused by pixbuf decoder state accumulation during dock operations.

* **Chores**
  * Bumped package version to v0.5.1.
  * Updated shared library dependency to v0.5.1 containing the memory optimization fix.
  * Updated project configuration for v0.5.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->