### PR TITLE
docs: clarify uwsm is optional in Hyprland autostart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ setup-hyprland:
 	@echo "#"
 	@echo "# Without uwsm (Slackware, distros where uwsm isn't packaged, or by preference):"
 	@echo "exec-once = $(BIN_NAME) -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c \"nwg-drawer --pb-auto\""
+	@echo "#"
+	@echo "# Note: nwg-dock has no runtime dependency on uwsm/systemd; the wrapper is optional."
 
 setup-sway:
 	@echo "# Add to ~/.config/sway/config:"

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,12 @@ uninstall:
 
 setup-hyprland:
 	@echo "# Add to ~/.config/hypr/autostart.conf:"
+	@echo "#"
+	@echo "# With uwsm (typical Arch+Hyprland; gives systemd-scoped session management):"
 	@echo "exec-once = uwsm-app -- $(BIN_NAME) -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c \"nwg-drawer --pb-auto\""
+	@echo "#"
+	@echo "# Without uwsm (Slackware, distros where uwsm isn't packaged, or by preference):"
+	@echo "exec-once = $(BIN_NAME) -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c \"nwg-drawer --pb-auto\""
 
 setup-sway:
 	@echo "# Add to ~/.config/sway/config:"

--- a/README.md
+++ b/README.md
@@ -189,10 +189,21 @@ make setup-sway
 
 ### Hyprland autostart example
 
+If you use [uwsm](https://github.com/Vladimir-csp/uwsm) for systemd-scoped session management (the typical Arch+Hyprland setup):
+
 ```ini
 # ~/.config/hypr/autostart.conf
 exec-once = uwsm-app -- nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c "nwg-drawer --opacity 88 --pb-auto"
 ```
+
+Without uwsm (Slackware, distros where `uwsm` isn't packaged, or by preference) — drop the `uwsm-app --` prefix:
+
+```ini
+# ~/.config/hypr/autostart.conf
+exec-once = nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c "nwg-drawer --opacity 88 --pb-auto"
+```
+
+The dock has no runtime dependency on uwsm or systemd; the wrapper just buys you per-process cgroup tracking and clean teardown on logout if you want it.
 
 ## Signal control
 


### PR DESCRIPTION
## Summary

- README "Hyprland autostart example" section now presents both variants — with `uwsm-app --` (typical Arch+Hyprland) and without it (Slackware, distros where `uwsm` isn't packaged, or by preference) — plus a one-liner noting the dock has no runtime dep on uwsm/systemd.
- `make setup-hyprland` mirrors that: prints both variants with the same short rationale.
- Sway autostart in the Makefile is unchanged (already doesn't reference uwsm).

## Why

Users on non-systemd distros and on systems where `uwsm` isn't packaged saw the recommended `uwsm-app -- nwg-dock …` line and reasonably assumed it was required. It isn't — `--wm uwsm` is opt-in (sets a launch-mode toggle in `nwg-common`), and `launch_via_uwsm` falls back to a direct spawn with a logged warning if the `uwsm` binary isn't on `$PATH`. The dock binary itself has zero uwsm references.

Refs: [jasonherald/nwg-notifications#63](https://github.com/jasonherald/nwg-notifications/issues/63) (cross-referencing for context; not closing — the notifications issue tracks the same theme separately).

## Test plan

- [x] Doc-only — exempt from smoke-test rule per project convention
- [x] `make setup-hyprland` output verified locally (both variants printed correctly)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Hyprland autostart examples to show both uwsm-wrapped and standard startup variants, with headers and explanatory notes.

* **Chores**
  * Updated setup guidance to provide a two-section autostart snippet covering uwsm-enabled and non-uwsm initialization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->