### PR TITLE
fix: hold gtk4::Application for process lifetime to survive transient monitor disconnects (#82)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,19 @@ struct DockBootstrap {
 /// Sets up the dock UI: state, monitors, windows, rebuild function, and listeners.
 fn activate_dock(app: &gtk4::Application, params: &DockBootstrap) {
     let css_handle = ui::css::load_dock_css(&params.css_path, params.config.opacity);
-    let _hold = app.hold();
+
+    // Hold the GTK Application for the lifetime of the process. Without
+    // this, when Hyprland reports the (only) monitor as disconnected
+    // during a sustained DPMS-off — which it does after ~5 minutes —
+    // GDK fires `items-changed`, our reconcile path destroys the dock
+    // window via `dock.win.destroy()`, and `gtk4::Application` then
+    // auto-exits because no windows remain. The user wakes up to find
+    // the dock gone (issue #82). The hold guard's `Drop` impl calls
+    // `release()`, so we deliberately leak it via `mem::forget` to keep
+    // the hold for the entire process lifetime; explicit `app.quit()`
+    // from the SIGRTMIN signal poller still exits regardless of the
+    // hold count.
+    std::mem::forget(app.hold());
 
     let state = Rc::new(RefCell::new(DockState::new(
         params.app_dirs.clone(),


### PR DESCRIPTION
## Summary

- One-line fix: `std::mem::forget(app.hold())` in `activate_dock` so the gtk4::Application's hold count stays bumped for the process lifetime instead of dropping when the function returns.
- Closes the silent-overnight-exit pattern from #82.
- Refs: #82.

## Why

After sustained DPMS-off (~5 min, reproducibly), Hyprland reports the monitor as disconnected and GDK fires \`items-changed\` with the monitor missing. Our \`reconcile_monitors\` calls \`remove_orphaned_docks\`, which destroys the dock window via \`dock.win.destroy()\`. With no \`GtkApplicationWindow\`s remaining, gtk4's Application defaults to exiting the process — clean shutdown, no panic, no coredump, no OOM, no journal entry. The user wakes up to find the dock gone.

The pre-existing \`let _hold = app.hold();\` was scoped to \`activate_dock\`, so the hold released as soon as that function returned. After that, only window count was keeping the application alive — exactly the wrong invariant for an app that may legitimately go through transient zero-window states.

## Mechanism after fix

1. DPMS-off → Hyprland reports DP-1 disconnect → GDK \`items-changed\` → \`reconcile_monitors\` → window destroyed.
2. **Process survives** because of the held Application reference.
3. Existing 2-second liveness tick catches the divergence (\`expected_monitors\` says DP-1, \`per_monitor\` is empty) and fires \`reconcile_monitors\` again.
4. This time \`add_new_docks\` runs because GDK has DP-1 listed → window recreated.
5. End-to-end recovery in ~3 seconds.

\`app.quit()\` from the SIGRTMIN signal poller still exits regardless of hold count, so the explicit-quit story is unchanged.

## Validation

Same 5-minute DPMS-off test driver from #82, before vs after this commit:

**Before fix** (binary timestamp May 5 14:33, v0.5.1):
```
13:36:28  Monitor topology changed, reconciling dock windows
13:36:28  Removing dock window for disconnected monitor: DP-1
[dock process exits silently]
```

**After fix** (this commit):
```
13:46:44  Monitor topology changed, reconciling dock windows
13:46:44  Removing dock window for disconnected monitor: DP-1
13:46:46  Monitor topology changed, reconciling dock windows
13:46:47  Liveness tick detected state drift, reconciling
13:46:47  Creating dock window for new monitor: DP-1
[dock process still alive, window back on screen]
```

User confirmed visually post-test: dock came back when the screen woke up.

## Test plan

- [x] \`cargo fmt --check\`, \`cargo build --release\`, \`cargo clippy --all-targets\`, \`cargo test\` — all clean (172 unit + 4 integration tests pass)
- [x] Manual repro: 5-minute \`hyprctl dispatch dpms off\` + \`dpms on\` cycle confirms dock survives and window is recreated
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application lifecycle management to ensure stable process retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->