### PR TITLE
Release nwg-dock v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-05-06
+
+### Fixed
+
+- Dock no longer disappears overnight when the screen is left
+  in DPMS-off / locked state for extended periods. Hyprland reports
+  the monitor as disconnected after sustained DPMS-off (~5 minutes
+  reproducibly), GDK propagates the topology change, and our
+  reconcile path destroys the dock window — at which point gtk4's
+  Application defaulted to exiting the process. The dock now holds
+  the gtk4::Application for its full lifetime via `mem::forget(app.hold())`,
+  so the process survives the transient zero-window state and the
+  liveness tick recreates the dock window when the monitor returns.
+  Total recovery is a few seconds; SIGRTMIN-driven `app.quit()` from
+  the signal poller still exits regardless of the hold count, so
+  intentional shutdown is unaffected. (#82)
+
 ## [0.5.1] — 2026-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-dock"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-dock"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 
 sonar.projectKey=nwg-dock
 sonar.projectName=nwg-dock
-sonar.projectVersion=0.5.1
+sonar.projectVersion=0.5.2
 
 # Source code location — standalone repo has src/ at root (not crates/*/src/)
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Cuts the v0.5.2 patch release. \`Cargo.toml\`, \`Cargo.lock\`, and \`sonar-project.properties\` bumped from 0.5.1 → 0.5.2.
- CHANGELOG entry points at the gtk4::Application hold-lifetime fix from #88.
- Headline user-facing change: dock no longer disappears overnight after sustained DPMS-off / screen-lock (#82).

## Post-merge steps

After this merges I'll:

1. Tag \`v0.5.2\` against the merge commit
2. \`cargo publish\` to crates.io

## Test plan

- [x] \`cargo build\`, \`cargo fmt --check\`, \`cargo clippy --all-targets\`, \`cargo test\` — all clean (172 unit tests + 4 integration tests pass)
- [x] Metadata-only change (no source code touched) — exempt from smoke-test rule per project convention; binary behaviour was already validated under #88's manual DPMS-off repro
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the dock would disappear when the screen remained in DPMS-off or locked state. The dock now recovers and reappears when the monitor returns to an active state.

* **Chores**
  * Version bumped to 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->